### PR TITLE
Fix extraneous skipped seq no

### DIFF
--- a/inc/clds/clds_sorted_list.h
+++ b/inc/clds/clds_sorted_list.h
@@ -39,7 +39,6 @@ typedef struct CLDS_SORTED_LIST_ITEM_TAG
     SORTED_LIST_ITEM_CLEANUP_CB item_cleanup_callback;
     void* item_cleanup_callback_context;
     volatile struct CLDS_SORTED_LIST_ITEM_TAG* next;
-    int64_t seq_no;
 } CLDS_SORTED_LIST_ITEM;
 
 // these are macros that help declaring a type that can be stored in the sorted list

--- a/src/clds_sorted_list.c
+++ b/src/clds_sorted_list.c
@@ -751,17 +751,18 @@ CLDS_SORTED_LIST_INSERT_RESULT clds_sorted_list_insert(CLDS_SORTED_LIST_HANDLE c
 
         bool restart_needed;
         void* new_item_key = clds_sorted_list->get_item_key_cb(clds_sorted_list->get_item_key_cb_context, item);
+        int64_t local_seq_no = 0;
 
         /* Codes_SRS_CLDS_SORTED_LIST_01_069: [ If no start sequence number was provided in clds_sorted_list_create and sequence_number is NULL, no sequence number computations shall be done. ]*/
         if (clds_sorted_list->sequence_number != NULL)
         {
             /* Codes_SRS_CLDS_SORTED_LIST_01_060: [ For each insert the order of the operation shall be computed based on the start sequence number passed to clds_sorted_list_create. ]*/
-            item->seq_no = InterlockedIncrement64(clds_sorted_list->sequence_number);
+            local_seq_no = InterlockedIncrement64(clds_sorted_list->sequence_number);
 
             /* Codes_SRS_CLDS_SORTED_LIST_01_061: [ If the sequence_number argument passed to clds_sorted_list_insert is NULL, the computed sequence number for the insert shall still be computed but it shall not be provided to the user. ]*/
             if (sequence_number != NULL)
             {
-                *sequence_number = item->seq_no;
+                *sequence_number = local_seq_no;
             }
         }
 
@@ -852,7 +853,7 @@ CLDS_SORTED_LIST_INSERT_RESULT clds_sorted_list_insert(CLDS_SORTED_LIST_HANDLE c
                         if (clds_sorted_list->skipped_seq_no_cb != NULL)
                         {
                             /* Codes_SRS_CLDS_SORTED_LIST_01_079: [** If sequence numbers are generated and a skipped sequence number callback was provided to clds_sorted_list_create, when the item is indicated as already existing, the generated sequence number shall be indicated as skipped. ]*/
-                            clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, item->seq_no);
+                            clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
                         }
 
                         LogError("Cannot acquire hazard pointer");
@@ -898,7 +899,7 @@ CLDS_SORTED_LIST_INSERT_RESULT clds_sorted_list_insert(CLDS_SORTED_LIST_HANDLE c
                                 if (clds_sorted_list->skipped_seq_no_cb != NULL)
                                 {
                                     /* Codes_SRS_CLDS_SORTED_LIST_01_079: [** If sequence numbers are generated and a skipped sequence number callback was provided to clds_sorted_list_create, when the item is indicated as already existing, the generated sequence number shall be indicated as skipped. ]*/
-                                    clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, item->seq_no);
+                                    clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
                                 }
 
                                 /* Codes_SRS_CLDS_SORTED_LIST_01_048: [ If the item with the given key already exists in the list, clds_sorted_list_insert shall fail and return CLDS_SORTED_LIST_INSERT_KEY_ALREADY_EXISTS. ]*/

--- a/src/clds_sorted_list.c
+++ b/src/clds_sorted_list.c
@@ -884,12 +884,6 @@ CLDS_SORTED_LIST_INSERT_RESULT clds_sorted_list_insert(CLDS_SORTED_LIST_HANDLE c
                             // item changed, it is likely that the node is no longer reachable, so we should not use its memory, restart
                             clds_hazard_pointers_release(clds_hazard_pointers_thread, current_item_hp);
 
-                            if (clds_sorted_list->skipped_seq_no_cb != NULL)
-                            {
-                                /* Codes_SRS_CLDS_SORTED_LIST_01_079: [** If sequence numbers are generated and a skipped sequence number callback was provided to clds_sorted_list_create, when the item is indicated as already existing, the generated sequence number shall be indicated as skipped. ]*/
-                                clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, item->seq_no);
-                            }
-
                             restart_needed = true;
                             break;
                         }

--- a/src/clds_sorted_list.c
+++ b/src/clds_sorted_list.c
@@ -252,9 +252,6 @@ static CLDS_SORTED_LIST_DELETE_RESULT internal_delete(CLDS_SORTED_LIST_HANDLE cl
                                 if (clds_sorted_list->sequence_number != NULL)
                                 {
                                     local_seq_no = InterlockedIncrement64(clds_sorted_list->sequence_number);
-
-                                    // get a new seq no and stamp it on the node to be deleted, if any other thread deletes they will alter the seq no.
-                                    (void)InterlockedExchange64(&current_item->seq_no, local_seq_no);
                                 }
 
                                 // the current node is marked for deletion, now try to change the previous link to the next value
@@ -274,6 +271,14 @@ static CLDS_SORTED_LIST_DELETE_RESULT internal_delete(CLDS_SORTED_LIST_HANDLE cl
 
                                         clds_hazard_pointers_release(clds_hazard_pointers_thread, current_item_hp);
 
+                                        if (
+                                            (clds_sorted_list->sequence_number != NULL) &&
+                                            (clds_sorted_list->skipped_seq_no_cb != NULL)
+                                            )
+                                        {
+                                            clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
+                                        }
+
                                         restart_needed = true;
                                         break;
                                     }
@@ -281,15 +286,6 @@ static CLDS_SORTED_LIST_DELETE_RESULT internal_delete(CLDS_SORTED_LIST_HANDLE cl
                                     {
                                         if (clds_sorted_list->sequence_number != NULL)
                                         {
-                                            int64_t temp_seq_no = InterlockedAdd64(&current_item->seq_no, 0);
-                                            if (temp_seq_no != local_seq_no)
-                                            {
-                                                if (clds_sorted_list->skipped_seq_no_cb != NULL)
-                                                {
-                                                    clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
-                                                }
-                                            }
-
                                             /* Codes_SRS_CLDS_SORTED_LIST_01_064: [ If the sequence_number argument passed to clds_sorted_list_delete is NULL, the computed sequence number for the delete shall still be computed but it shall not be provided to the user. ]*/
                                             /* Codes_SRS_CLDS_SORTED_LIST_01_067: [ If the sequence_number argument passed to clds_sorted_list_delete_key is NULL, the computed sequence number for the delete shall still be computed but it shall not be provided to the user. ]*/
                                             if (sequence_number != NULL)
@@ -297,7 +293,7 @@ static CLDS_SORTED_LIST_DELETE_RESULT internal_delete(CLDS_SORTED_LIST_HANDLE cl
                                                 // since we deleted the node, simply pick up the current sequence number (has to be greater than the insert)
                                                 /* Codes_SRS_CLDS_SORTED_LIST_01_063: [ For each delete the order of the operation shall be computed based on the start sequence number passed to clds_sorted_list_create. ]*/
                                                 /* Codes_SRS_CLDS_SORTED_LIST_01_066: [ For each delete key the order of the operation shall be computed based on the start sequence number passed to clds_sorted_list_create. ]*/
-                                                *sequence_number = temp_seq_no;
+                                                *sequence_number = local_seq_no;
                                             }
                                         }
 
@@ -327,6 +323,14 @@ static CLDS_SORTED_LIST_DELETE_RESULT internal_delete(CLDS_SORTED_LIST_HANDLE cl
                                         clds_hazard_pointers_release(clds_hazard_pointers_thread, previous_hp);
                                         clds_hazard_pointers_release(clds_hazard_pointers_thread, current_item_hp);
 
+                                        if (
+                                            (clds_sorted_list->sequence_number != NULL) &&
+                                            (clds_sorted_list->skipped_seq_no_cb != NULL)
+                                            )
+                                        {
+                                            clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
+                                        }
+
                                         restart_needed = true;
                                         break;
                                     }
@@ -334,15 +338,6 @@ static CLDS_SORTED_LIST_DELETE_RESULT internal_delete(CLDS_SORTED_LIST_HANDLE cl
                                     {
                                         if (clds_sorted_list->sequence_number != NULL)
                                         {
-                                            int64_t temp_seq_no = InterlockedAdd64(&current_item->seq_no, 0);
-                                            if (temp_seq_no != local_seq_no)
-                                            {
-                                                if (clds_sorted_list->skipped_seq_no_cb != NULL)
-                                                {
-                                                    clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
-                                                }
-                                            }
-
                                             /* Codes_SRS_CLDS_SORTED_LIST_01_064: [ If the sequence_number argument passed to clds_sorted_list_delete is NULL, the computed sequence number for the delete shall still be computed but it shall not be provided to the user. ]*/
                                             /* Codes_SRS_CLDS_SORTED_LIST_01_067: [ If the sequence_number argument passed to clds_sorted_list_delete_key is NULL, the computed sequence number for the delete shall still be computed but it shall not be provided to the user. ]*/
                                             if (sequence_number != NULL)
@@ -350,7 +345,7 @@ static CLDS_SORTED_LIST_DELETE_RESULT internal_delete(CLDS_SORTED_LIST_HANDLE cl
                                                 // since we deleted the node, simply pick up the current sequence number (has to be greater than the insert)
                                                 /* Codes_SRS_CLDS_SORTED_LIST_01_063: [ For each delete the order of the operation shall be computed based on the start sequence number passed to clds_sorted_list_create. ]*/
                                                 /* Codes_SRS_CLDS_SORTED_LIST_01_066: [ For each delete key the order of the operation shall be computed based on the start sequence number passed to clds_sorted_list_create. ]*/
-                                                *sequence_number = temp_seq_no;
+                                                *sequence_number = local_seq_no;
                                             }
                                         }
 
@@ -503,11 +498,8 @@ static CLDS_SORTED_LIST_REMOVE_RESULT internal_remove(CLDS_SORTED_LIST_HANDLE cl
                                 /* Codes_SRS_CLDS_SORTED_LIST_01_073: [ If no start sequence number was provided in clds_sorted_list_create and sequence_number is NULL, no sequence number computations shall be done. ]*/
                                 if (clds_sorted_list->sequence_number != NULL)
                                 {
-                                    local_seq_no = InterlockedIncrement64(clds_sorted_list->sequence_number);
-
-                                    // get a new seq no and stamp it on the node to be deleted, if any other thread deletes they will alter the seq no.
                                     /* Codes_SRS_CLDS_SORTED_LIST_01_074: [ If the sequence_number argument passed to clds_sorted_list_remove_key is NULL, the computed sequence number for the remove shall still be computed but it shall not be provided to the user. ]*/
-                                    (void)InterlockedExchange64(&current_item->seq_no, local_seq_no);
+                                    local_seq_no = InterlockedIncrement64(clds_sorted_list->sequence_number);
                                 }
 
                                 // the current node is marked for deletion, now try to change the previous link to the next value
@@ -525,6 +517,14 @@ static CLDS_SORTED_LIST_REMOVE_RESULT internal_remove(CLDS_SORTED_LIST_HANDLE cl
 
                                         clds_hazard_pointers_release(clds_hazard_pointers_thread, current_item_hp);
 
+                                        if (
+                                            (clds_sorted_list->sequence_number != NULL) &&
+                                            (clds_sorted_list->skipped_seq_no_cb != NULL)
+                                            )
+                                        {
+                                            clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
+                                        }
+
                                         restart_needed = true;
                                         break;
                                     }
@@ -536,20 +536,11 @@ static CLDS_SORTED_LIST_REMOVE_RESULT internal_remove(CLDS_SORTED_LIST_HANDLE cl
 
                                         if (clds_sorted_list->sequence_number != NULL)
                                         {
-                                            int64_t temp_seq_no = InterlockedAdd64(&current_item->seq_no, 0);
-                                            if (temp_seq_no != local_seq_no)
-                                            {
-                                                if (clds_sorted_list->skipped_seq_no_cb != NULL)
-                                                {
-                                                    clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
-                                                }
-                                            }
-
                                             if (sequence_number != NULL)
                                             {
                                                 // since we deleted the node, simply pick up the current sequence number (has to be greater than the insert)
                                                 /* Codes_SRS_CLDS_SORTED_LIST_01_072: [ For each remove key the order of the operation shall be computed based on the start sequence number passed to clds_sorted_list_create. ]*/
-                                                *sequence_number = temp_seq_no;
+                                                *sequence_number = local_seq_no;
                                             }
                                         }
 
@@ -577,6 +568,14 @@ static CLDS_SORTED_LIST_REMOVE_RESULT internal_remove(CLDS_SORTED_LIST_HANDLE cl
                                         clds_hazard_pointers_release(clds_hazard_pointers_thread, previous_hp);
                                         clds_hazard_pointers_release(clds_hazard_pointers_thread, current_item_hp);
 
+                                        if (
+                                            (clds_sorted_list->sequence_number != NULL) &&
+                                            (clds_sorted_list->skipped_seq_no_cb != NULL)
+                                            )
+                                        {
+                                            clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
+                                        }
+
                                         restart_needed = true;
                                         break;
                                     }
@@ -588,20 +587,11 @@ static CLDS_SORTED_LIST_REMOVE_RESULT internal_remove(CLDS_SORTED_LIST_HANDLE cl
 
                                         if (clds_sorted_list->sequence_number != NULL)
                                         {
-                                            int64_t temp_seq_no = InterlockedAdd64(&current_item->seq_no, 0);
-                                            if (temp_seq_no != local_seq_no)
-                                            {
-                                                if (clds_sorted_list->skipped_seq_no_cb != NULL)
-                                                {
-                                                    clds_sorted_list->skipped_seq_no_cb(clds_sorted_list->skipped_seq_no_cb_context, local_seq_no);
-                                                }
-                                            }
-
                                             if (sequence_number != NULL)
                                             {
                                                 // since we deleted the node, simply pick up the current sequence number (has to be greater than the insert)
                                                 /* Codes_SRS_CLDS_SORTED_LIST_01_072: [ For each remove key the order of the operation shall be computed based on the start sequence number passed to clds_sorted_list_create. ]*/
-                                                *sequence_number = temp_seq_no;
+                                                *sequence_number = local_seq_no;
                                             }
                                         }
 

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -112,7 +112,7 @@ static void mark_seq_no_as_used(CHAOS_TEST_CONTEXT* chaos_test_context, int64_t 
     WakeByAddressSingle((PVOID)&chaos_test_context->seq_numbers[seq_no & TEST_SEQ_NO_QUEUE_SIZE]);
 }
 
-static void test_skipped_seq_no_count(void* context, int64_t skipped_sequence_no)
+static void test_skipped_seq_chaos(void* context, int64_t skipped_sequence_no)
 {
     CHAOS_TEST_CONTEXT* chaos_test_context = (CHAOS_TEST_CONTEXT*)context;
     mark_seq_no_as_used(chaos_test_context, skipped_sequence_no);
@@ -1699,7 +1699,7 @@ TEST_FUNCTION(clds_hash_table_chaos_knight_test)
         (void)InterlockedExchange(&chaos_test_context->items[i].item_state, TEST_HASH_TABLE_ITEM_NOT_USED);
     }
 
-    chaos_test_context->hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 8, hazard_pointers, &sequence_number, test_skipped_seq_no_count, (void*)chaos_test_context);
+    chaos_test_context->hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 8, hazard_pointers, &sequence_number, test_skipped_seq_chaos, chaos_test_context);
     ASSERT_IS_NOT_NULL(chaos_test_context->hash_table);
 
     (void)InterlockedExchange(&chaos_test_context->done, 0);

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -1681,8 +1681,10 @@ TEST_FUNCTION(clds_hash_table_chaos_knight_test)
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
     THREAD_HANDLE seq_no_clean_thread_handle;
-    volatile int64_t sequence_number = 0;
+    volatile int64_t sequence_number;
     size_t i;
+
+    (void)InterlockedExchange64(&sequence_number, 0);
 
     CHAOS_TEST_CONTEXT* chaos_test_context = (CHAOS_TEST_CONTEXT*)malloc(sizeof(CHAOS_TEST_CONTEXT) + (sizeof(CHAOS_TEST_ITEM_DATA) * CHAOS_ITEM_COUNT));
     ASSERT_IS_NOT_NULL(chaos_test_context);

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -1742,7 +1742,7 @@ TEST_FUNCTION(clds_hash_table_chaos_knight_test)
 
     ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(seq_no_clean_thread_handle, &dont_care), "Sequence number clean thread handle join failed");
 
-    ASSERT_ARE_EQUAL(int64_t, InterlockedAdd64(&sequence_number, -1), InterlockedAdd64(&chaos_test_context->seq_no_count, 0));
+    ASSERT_ARE_EQUAL(int64_t, InterlockedAdd64(&sequence_number, 0), InterlockedAdd64(&chaos_test_context->seq_no_count, 0));
 
     // cleanup
     free(chaos_thread_data);

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -1695,7 +1695,7 @@ TEST_FUNCTION(clds_hash_table_chaos_knight_test)
     }
 
     (void)InterlockedExchange64(&chaos_test_context->seq_no_count, 0);
-    (void)InterlockedExchange64(&chaos_test_context->next_seq_no_to_ack, 1);
+    chaos_test_context->next_seq_no_to_ack = 1;
 
     for (i = 0; i < CHAOS_ITEM_COUNT; i++)
     {

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -107,7 +107,7 @@ static int test_key_compare(void* key1, void* key2)
 static void mark_seq_no_as_used(CHAOS_TEST_CONTEXT* chaos_test_context, int64_t seq_no)
 {
     (void)InterlockedIncrement64(&chaos_test_context->seq_no_count);
-    SEQ_NO_STATE seq_no_state = InterlockedCompareExchange(&chaos_test_context->seq_numbers[seq_no % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, SEQ_NO_NOT_USED);
+    SEQ_NO_STATE seq_no_state = (SEQ_NO_STATE)InterlockedCompareExchange(&chaos_test_context->seq_numbers[seq_no % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, SEQ_NO_NOT_USED);
     ASSERT_ARE_EQUAL(SEQ_NO_STATE, SEQ_NO_NOT_USED, seq_no_state, "sequence number already used at %" PRId64 "", seq_no);
     WakeByAddressSingle((PVOID)&chaos_test_context->seq_numbers[seq_no & TEST_SEQ_NO_QUEUE_SIZE]);
 }

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -1668,6 +1668,7 @@ static int seq_no_clean_thread(void* arg)
         {
             chaos_test_context->next_seq_no_to_ack++;
         }
+        LogInfo("Advanced indicated sequence number to %" PRId64 "", chaos_test_context->next_seq_no_to_ack);
         (void)InterlockedHL_WaitForValue(&chaos_test_context->seq_numbers[chaos_test_context->next_seq_no_to_ack % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, 1000);
     }
 

--- a/tests/clds_sorted_list_int/clds_sorted_list_int.c
+++ b/tests/clds_sorted_list_int/clds_sorted_list_int.c
@@ -1568,8 +1568,10 @@ TEST_FUNCTION(clds_sorted_list_chaos_knight_test)
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
     THREAD_HANDLE seq_no_clean_thread_handle;
-    volatile int64_t sequence_number = 0;
+    volatile int64_t sequence_number;
     size_t i;
+
+    (void)InterlockedExchange64(&sequence_number, 0);
 
     CHAOS_TEST_CONTEXT* chaos_test_context = (CHAOS_TEST_CONTEXT*)malloc(sizeof(CHAOS_TEST_CONTEXT) + (sizeof(CHAOS_TEST_ITEM_DATA) * CHAOS_ITEM_COUNT));
     ASSERT_IS_NOT_NULL(chaos_test_context);

--- a/tests/clds_sorted_list_int/clds_sorted_list_int.c
+++ b/tests/clds_sorted_list_int/clds_sorted_list_int.c
@@ -16,6 +16,7 @@
 
 #include "windows.h"
 
+#include "azure_c_pal/interlocked_hl.h"
 #include "azure_c_logging/xlogging.h"
 
 #include "azure_c_pal/timer.h"
@@ -31,11 +32,19 @@ static TEST_MUTEX_HANDLE test_serialize_mutex;
 
 #define XTEST_FUNCTION(A) void A(void)
 
+#define SEQ_NO_STATE_VALUES \
+    SEQ_NO_NOT_USED, \
+    SEQ_NO_USED
+
+MU_DEFINE_ENUM(SEQ_NO_STATE, SEQ_NO_STATE_VALUES);
+
 TEST_DEFINE_ENUM_TYPE(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(THREADAPI_RESULT, THREADAPI_RESULT_VALUES);
+TEST_DEFINE_ENUM_TYPE(SEQ_NO_STATE, SEQ_NO_STATE_VALUES);
+TEST_DEFINE_ENUM_TYPE(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_RESULT_VALUES);
 
 typedef struct TEST_ITEM_TAG
 {
@@ -133,10 +142,15 @@ typedef struct CHAOS_TEST_ITEM_DATA_TAG
     volatile LONG item_state;
 } CHAOS_TEST_ITEM_DATA;
 
+#define TEST_SEQ_NO_QUEUE_SIZE (1024 * 1024)
+
 typedef struct CHAOS_TEST_CONTEXT_TAG
 {
     volatile LONG done;
     CLDS_SORTED_LIST_HANDLE sorted_list;
+    volatile LONG64 seq_no_count;
+    int64_t next_seq_no_to_ack;
+    volatile LONG seq_numbers[TEST_SEQ_NO_QUEUE_SIZE];
     CHAOS_TEST_ITEM_DATA items[];
 } CHAOS_TEST_CONTEXT;
 
@@ -1281,6 +1295,20 @@ static bool get_item_and_change_state(CHAOS_TEST_ITEM_DATA* items, int item_coun
     return result;
 }
 
+static void mark_seq_no_as_used(CHAOS_TEST_CONTEXT* chaos_test_context, int64_t seq_no)
+{
+    (void)InterlockedIncrement64(&chaos_test_context->seq_no_count);
+    SEQ_NO_STATE seq_no_state = InterlockedCompareExchange(&chaos_test_context->seq_numbers[seq_no % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, SEQ_NO_NOT_USED);
+    ASSERT_ARE_EQUAL(SEQ_NO_STATE, SEQ_NO_NOT_USED, seq_no_state, "sequence number already used at %" PRId64 "", seq_no);
+    WakeByAddressSingle((PVOID)&chaos_test_context->seq_numbers[seq_no & TEST_SEQ_NO_QUEUE_SIZE]);
+}
+
+static void test_skipped_seq_chaos(void* context, int64_t skipped_sequence_no)
+{
+    CHAOS_TEST_CONTEXT* chaos_test_context = (CHAOS_TEST_CONTEXT*)context;
+    mark_seq_no_as_used(chaos_test_context, skipped_sequence_no);
+}
+
 static int chaos_thread(void* arg)
 {
     int result;
@@ -1294,7 +1322,7 @@ static int chaos_thread(void* arg)
         // perform one of the several actions
         CHAOS_TEST_ACTION action = (CHAOS_TEST_ACTION)(rand() * ((MU_COUNT_ARG(CHAOS_TEST_ACTION_VALUES)) - 1) / RAND_MAX);
         int item_index;
-        int64_t seq_no;
+        int64_t seq_no = 0;
 
         // each thread decides on a random action to execute: inserts, deletes, removes and finds
         switch (action)
@@ -1310,6 +1338,8 @@ static int chaos_thread(void* arg)
                 item_payload->key = item_index + 1;
 
                 ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_OK, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, chaos_test_context->items[item_index].item, &seq_no));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
 
                 (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
             }
@@ -1319,175 +1349,190 @@ static int chaos_thread(void* arg)
             if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
             {
                 ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_OK, clds_sorted_list_delete_item(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, chaos_test_context->items[item_index].item, &seq_no));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
             
                 (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
             }
             break;
 
         case CHAOS_TEST_ACTION_DELETE_KEY:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            {
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_OK, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_OK, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
+            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+            //    mark_seq_no_as_used(chaos_test_context, seq_no);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_REMOVE_KEY:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* removed_item;
-            
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-            
-                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, removed_item);
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* removed_item;
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+            //    mark_seq_no_as_used(chaos_test_context, seq_no);
+            //
+            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, removed_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_INSERT_KEY_TWICE:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_INSERTING_AGAIN, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* new_item;
-                new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-                TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
-                item_payload->key = item_index + 1;
-            
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_KEY_ALREADY_EXISTS, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, chaos_test_context->items[item_index].item, &seq_no));
-            
-                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_INSERTING_AGAIN, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* new_item;
+            //    new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
+            //    TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
+            //    item_payload->key = item_index + 1;
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_KEY_ALREADY_EXISTS, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, chaos_test_context->items[item_index].item, &seq_no));
+            //
+            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_DELETE_KEY_NOT_FOUND:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
-            {
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_NOT_FOUND, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
+            //{
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_NOT_FOUND, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_REMOVE_KEY_NOT_FOUND:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* removed_item;
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_NOT_FOUND, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* removed_item;
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_NOT_FOUND, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_FIND:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
-                ASSERT_IS_NOT_NULL(found_item);
-            
-                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, found_item);
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
+            //    ASSERT_IS_NOT_NULL(found_item);
+            //
+            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, found_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_FIND_NOT_FOUND:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_NOT_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
-                ASSERT_IS_NULL(found_item);
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_NOT_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
+            //    ASSERT_IS_NULL(found_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_SET_VALUE:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* old_item;
-                chaos_test_context->items[item_index].item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-                TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, chaos_test_context->items[item_index].item);
-                item_payload->key = item_index + 1;
-            
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
-            
-                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* old_item;
+            //    chaos_test_context->items[item_index].item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
+            //    TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, chaos_test_context->items[item_index].item);
+            //    item_payload->key = item_index + 1;
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
+            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+            //    mark_seq_no_as_used(chaos_test_context, seq_no);
+            //
+            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_SET_VALUE_SAME_ITEM:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* old_item;
-                CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
-
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
-
-                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
-
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* old_item;
+            //    CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
+            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+            //    mark_seq_no_as_used(chaos_test_context, seq_no);
+            //
+            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            //}
             break;
         case CHAOS_TEST_ACTION_REMOVE_AND_SET:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* removed_item;
-                CLDS_SORTED_LIST_ITEM* old_item;
-            
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), removed_item, &old_item, &seq_no, false));
-            
-                ASSERT_IS_NULL(old_item);
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* removed_item;
+            //    CLDS_SORTED_LIST_ITEM* old_item;
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+            //    mark_seq_no_as_used(chaos_test_context, seq_no);
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), removed_item, &old_item, &seq_no, false));
+            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+            //    mark_seq_no_as_used(chaos_test_context, seq_no);
+            //
+            //    ASSERT_IS_NULL(old_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_REMOVE_AND_INSERT:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* removed_item;
-            
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_OK, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, removed_item, &seq_no));
-            
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* removed_item;
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_OK, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, removed_item, &seq_no));
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            //}
             break;
 
         case CHAOS_TEST_ACTION_SET_VALUE_ONLY_IF_EXISTS:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* old_item;
-                CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
-
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, true));
-
-                ASSERT_IS_NOT_NULL(old_item);
-                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
-
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* old_item;
+            //    CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, true));
+            //
+            //    ASSERT_IS_NOT_NULL(old_item);
+            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            //}
             break;
         case CHAOS_TEST_ACTION_SET_VALUE_ONLY_IF_EXISTS_WHEN_NODE_NOT_THERE:
-            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_NOT_USED, &item_index))
-            {
-                CLDS_SORTED_LIST_ITEM* old_item;
-                CLDS_SORTED_LIST_ITEM* new_item;
-                new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-                TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
-                item_payload->key = item_index + 1;
-
-                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_NOT_FOUND, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), new_item, &old_item, &seq_no, true));
-
-                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
-
-                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            }
+            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_NOT_USED, &item_index))
+            //{
+            //    CLDS_SORTED_LIST_ITEM* old_item;
+            //    CLDS_SORTED_LIST_ITEM* new_item;
+            //    new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
+            //    TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
+            //    item_payload->key = item_index + 1;
+            //
+            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_NOT_FOUND, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), new_item, &old_item, &seq_no, true));
+            //
+            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
+            //
+            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            //}
             break;
         }
     }
@@ -1497,22 +1542,49 @@ static int chaos_thread(void* arg)
     return result;
 }
 
+static int seq_no_clean_thread(void* arg)
+{
+    CHAOS_TEST_CONTEXT* chaos_test_context = (CHAOS_TEST_CONTEXT*)arg;
+
+    while (InterlockedAdd(&chaos_test_context->done, 0) != 1)
+    {
+        while (InterlockedCompareExchange(&chaos_test_context->seq_numbers[chaos_test_context->next_seq_no_to_ack % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_NOT_USED, SEQ_NO_USED) == SEQ_NO_USED)
+        {
+            chaos_test_context->next_seq_no_to_ack++;
+        }
+        LogInfo("Advanced to %" PRId64 "", chaos_test_context->next_seq_no_to_ack);
+        (void)InterlockedHL_WaitForValue(&chaos_test_context->seq_numbers[chaos_test_context->next_seq_no_to_ack % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, 1000);
+    }
+
+    ThreadAPI_Exit(0);
+    return 0;
+}
+
 TEST_FUNCTION(clds_sorted_list_chaos_knight_test)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    volatile int64_t sequence_number = -1;
+    THREAD_HANDLE seq_no_clean_thread_handle;
+    volatile int64_t sequence_number = 0;
     size_t i;
 
     CHAOS_TEST_CONTEXT* chaos_test_context = (CHAOS_TEST_CONTEXT*)malloc(sizeof(CHAOS_TEST_CONTEXT) + (sizeof(CHAOS_TEST_ITEM_DATA) * CHAOS_ITEM_COUNT));
     ASSERT_IS_NOT_NULL(chaos_test_context);
+
+    for (i = 0; i < TEST_SEQ_NO_QUEUE_SIZE; i++)
+    {
+        (void)InterlockedExchange(&chaos_test_context->seq_numbers[i], SEQ_NO_NOT_USED);
+    }
+
+    (void)InterlockedExchange64(&chaos_test_context->seq_no_count, 0);
+    (void)InterlockedExchange64(&chaos_test_context->next_seq_no_to_ack, 1);
 
     for (i = 0; i < CHAOS_ITEM_COUNT; i++)
     {
         (void)InterlockedExchange(&chaos_test_context->items[i].item_state, TEST_LIST_ITEM_NOT_USED);
     }
 
-    chaos_test_context->sorted_list = clds_sorted_list_create(hazard_pointers, test_get_item_key, (void*)0x4242, test_key_compare, (void*)0x4243, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    chaos_test_context->sorted_list = clds_sorted_list_create(hazard_pointers, test_get_item_key, (void*)0x4242, test_key_compare, (void*)0x4243, &sequence_number, test_skipped_seq_chaos, chaos_test_context);
     ASSERT_IS_NOT_NULL(chaos_test_context->sorted_list);
 
     (void)InterlockedExchange(&chaos_test_context->done, 0);
@@ -1521,6 +1593,8 @@ TEST_FUNCTION(clds_sorted_list_chaos_knight_test)
     CHAOS_THREAD_DATA* chaos_thread_data = (CHAOS_THREAD_DATA*)malloc(sizeof(CHAOS_THREAD_DATA) * CHAOS_THREAD_COUNT);
     ASSERT_IS_NOT_NULL(chaos_thread_data);
 
+    ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&seq_no_clean_thread_handle, seq_no_clean_thread, chaos_test_context), "Error spawning sequence number clean thread");
+
     for (i = 0; i < CHAOS_THREAD_COUNT; i++)
     {
         chaos_thread_data[i].chaos_test_context = chaos_test_context;
@@ -1528,11 +1602,7 @@ TEST_FUNCTION(clds_sorted_list_chaos_knight_test)
         chaos_thread_data[i].clds_hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
         ASSERT_IS_NOT_NULL(chaos_thread_data[i].clds_hazard_pointers_thread);
 
-        if (ThreadAPI_Create(&chaos_thread_data[i].thread_handle, chaos_thread, &chaos_thread_data[i]) != THREADAPI_OK)
-        {
-            ASSERT_FAIL("Error spawning test thread");
-            break;
-        }
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&chaos_thread_data[i].thread_handle, chaos_thread, &chaos_thread_data[i]));
     }
 
     double start_time = timer_global_get_elapsed_ms();
@@ -1546,12 +1616,15 @@ TEST_FUNCTION(clds_sorted_list_chaos_knight_test)
 
     (void)InterlockedExchange(&chaos_test_context->done, 1);
 
+    int dont_care;
+
     // assert
     for (i = 0; i < CHAOS_THREAD_COUNT; i++)
     {
-        int dont_care;
         ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(chaos_thread_data[i].thread_handle, &dont_care), "Thread %zu failed to join", i);
     }
+
+    ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(seq_no_clean_thread_handle, &dont_care), "Sequence number clean thread handle join failed");
 
     // cleanup
     free(chaos_thread_data);

--- a/tests/clds_sorted_list_int/clds_sorted_list_int.c
+++ b/tests/clds_sorted_list_int/clds_sorted_list_int.c
@@ -1582,7 +1582,7 @@ TEST_FUNCTION(clds_sorted_list_chaos_knight_test)
     }
 
     (void)InterlockedExchange64(&chaos_test_context->seq_no_count, 0);
-    (void)InterlockedExchange64(&chaos_test_context->next_seq_no_to_ack, 1);
+    chaos_test_context->next_seq_no_to_ack = 1;
 
     for (i = 0; i < CHAOS_ITEM_COUNT; i++)
     {

--- a/tests/clds_sorted_list_int/clds_sorted_list_int.c
+++ b/tests/clds_sorted_list_int/clds_sorted_list_int.c
@@ -1629,6 +1629,8 @@ TEST_FUNCTION(clds_sorted_list_chaos_knight_test)
 
     ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(seq_no_clean_thread_handle, &dont_care), "Sequence number clean thread handle join failed");
 
+    ASSERT_ARE_EQUAL(int64_t, InterlockedAdd64(&sequence_number, 0), InterlockedAdd64(&chaos_test_context->seq_no_count, 0));
+
     // cleanup
     free(chaos_thread_data);
     clds_sorted_list_destroy(chaos_test_context->sorted_list);

--- a/tests/clds_sorted_list_int/clds_sorted_list_int.c
+++ b/tests/clds_sorted_list_int/clds_sorted_list_int.c
@@ -1357,182 +1357,185 @@ static int chaos_thread(void* arg)
             break;
 
         case CHAOS_TEST_ACTION_DELETE_KEY:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_OK, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
-            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
-            //    mark_seq_no_as_used(chaos_test_context, seq_no);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            {
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_OK, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_REMOVE_KEY:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* removed_item;
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
-            //    mark_seq_no_as_used(chaos_test_context, seq_no);
-            //
-            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, removed_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* removed_item;
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, removed_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_INSERT_KEY_TWICE:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_INSERTING_AGAIN, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* new_item;
-            //    new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-            //    TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
-            //    item_payload->key = item_index + 1;
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_KEY_ALREADY_EXISTS, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, chaos_test_context->items[item_index].item, &seq_no));
-            //
-            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_INSERTING_AGAIN, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* new_item;
+                new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
+                TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
+                item_payload->key = item_index + 1;
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_KEY_ALREADY_EXISTS, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, chaos_test_context->items[item_index].item, &seq_no));
+            
+                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_DELETE_KEY_NOT_FOUND:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
-            //{
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_NOT_FOUND, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
+            {
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_DELETE_RESULT, CLDS_SORTED_LIST_DELETE_NOT_FOUND, clds_sorted_list_delete_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &seq_no));
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_REMOVE_KEY_NOT_FOUND:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* removed_item;
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_NOT_FOUND, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_NOT_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* removed_item;
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_NOT_FOUND, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_FIND:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
-            //    ASSERT_IS_NOT_NULL(found_item);
-            //
-            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, found_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
+                ASSERT_IS_NOT_NULL(found_item);
+            
+                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, found_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_FIND_NOT_FOUND:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_NOT_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
-            //    ASSERT_IS_NULL(found_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_FINDING, TEST_LIST_ITEM_NOT_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* found_item = clds_sorted_list_find_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1));
+                ASSERT_IS_NULL(found_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_SET_VALUE:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* old_item;
-            //    chaos_test_context->items[item_index].item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-            //    TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, chaos_test_context->items[item_index].item);
-            //    item_payload->key = item_index + 1;
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
-            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
-            //    mark_seq_no_as_used(chaos_test_context, seq_no);
-            //
-            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* old_item;
+                chaos_test_context->items[item_index].item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
+                TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, chaos_test_context->items[item_index].item);
+                item_payload->key = item_index + 1;
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_SET_VALUE_SAME_ITEM:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* old_item;
-            //    CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
-            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
-            //    mark_seq_no_as_used(chaos_test_context, seq_no);
-            //
-            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* old_item;
+                CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, false));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            }
             break;
         case CHAOS_TEST_ACTION_REMOVE_AND_SET:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* removed_item;
-            //    CLDS_SORTED_LIST_ITEM* old_item;
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
-            //    mark_seq_no_as_used(chaos_test_context, seq_no);
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), removed_item, &old_item, &seq_no, false));
-            //    ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
-            //    mark_seq_no_as_used(chaos_test_context, seq_no);
-            //
-            //    ASSERT_IS_NULL(old_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* removed_item;
+                CLDS_SORTED_LIST_ITEM* old_item;
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), removed_item, &old_item, &seq_no, false));
+                ASSERT_ARE_NOT_EQUAL(int64_t, 0, seq_no);
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                ASSERT_IS_NULL(old_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_REMOVE_AND_INSERT:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* removed_item;
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_OK, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, removed_item, &seq_no));
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_DELETING, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* removed_item;
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_REMOVE_RESULT, CLDS_SORTED_LIST_REMOVE_OK, clds_sorted_list_remove_key(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), &removed_item, &seq_no));
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_OK, clds_sorted_list_insert(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, removed_item, &seq_no));
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            }
             break;
 
         case CHAOS_TEST_ACTION_SET_VALUE_ONLY_IF_EXISTS:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* old_item;
-            //    CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, true));
-            //
-            //    ASSERT_IS_NOT_NULL(old_item);
-            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* old_item;
+                CLDS_SORTED_LIST_NODE_INC_REF(TEST_ITEM, chaos_test_context->items[item_index].item);
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_OK, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), chaos_test_context->items[item_index].item, &old_item, &seq_no, true));
+                mark_seq_no_as_used(chaos_test_context, seq_no);
+            
+                ASSERT_IS_NOT_NULL(old_item);
+                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, old_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_USED);
+            }
             break;
         case CHAOS_TEST_ACTION_SET_VALUE_ONLY_IF_EXISTS_WHEN_NODE_NOT_THERE:
-            //if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_NOT_USED, &item_index))
-            //{
-            //    CLDS_SORTED_LIST_ITEM* old_item;
-            //    CLDS_SORTED_LIST_ITEM* new_item;
-            //    new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-            //    TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
-            //    item_payload->key = item_index + 1;
-            //
-            //    ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_NOT_FOUND, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), new_item, &old_item, &seq_no, true));
-            //
-            //    CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
-            //
-            //    (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
-            //}
+            if (get_item_and_change_state(chaos_test_context->items, CHAOS_ITEM_COUNT, TEST_LIST_ITEM_SETTING_VALUE, TEST_LIST_ITEM_NOT_USED, &item_index))
+            {
+                CLDS_SORTED_LIST_ITEM* old_item;
+                CLDS_SORTED_LIST_ITEM* new_item;
+                new_item = CLDS_SORTED_LIST_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
+                TEST_ITEM* item_payload = CLDS_SORTED_LIST_GET_VALUE(TEST_ITEM, new_item);
+                item_payload->key = item_index + 1;
+            
+                ASSERT_ARE_EQUAL(CLDS_SORTED_LIST_SET_VALUE_RESULT, CLDS_SORTED_LIST_SET_VALUE_NOT_FOUND, clds_sorted_list_set_value(chaos_test_context->sorted_list, chaos_thread_data->clds_hazard_pointers_thread, (void*)(uintptr_t)(item_index + 1), new_item, &old_item, &seq_no, true));
+            
+                CLDS_SORTED_LIST_NODE_RELEASE(TEST_ITEM, new_item);
+            
+                (void)InterlockedExchange(&chaos_test_context->items[item_index].item_state, TEST_LIST_ITEM_NOT_USED);
+            }
             break;
         }
     }
@@ -1552,7 +1555,7 @@ static int seq_no_clean_thread(void* arg)
         {
             chaos_test_context->next_seq_no_to_ack++;
         }
-        LogInfo("Advanced to %" PRId64 "", chaos_test_context->next_seq_no_to_ack);
+        LogInfo("Advanced indicated sequence number to %" PRId64 "", chaos_test_context->next_seq_no_to_ack);
         (void)InterlockedHL_WaitForValue(&chaos_test_context->seq_numbers[chaos_test_context->next_seq_no_to_ack % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, 1000);
     }
 

--- a/tests/clds_sorted_list_int/clds_sorted_list_int.c
+++ b/tests/clds_sorted_list_int/clds_sorted_list_int.c
@@ -1298,7 +1298,7 @@ static bool get_item_and_change_state(CHAOS_TEST_ITEM_DATA* items, int item_coun
 static void mark_seq_no_as_used(CHAOS_TEST_CONTEXT* chaos_test_context, int64_t seq_no)
 {
     (void)InterlockedIncrement64(&chaos_test_context->seq_no_count);
-    SEQ_NO_STATE seq_no_state = InterlockedCompareExchange(&chaos_test_context->seq_numbers[seq_no % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, SEQ_NO_NOT_USED);
+    SEQ_NO_STATE seq_no_state = (SEQ_NO_STATE)InterlockedCompareExchange(&chaos_test_context->seq_numbers[seq_no % TEST_SEQ_NO_QUEUE_SIZE], SEQ_NO_USED, SEQ_NO_NOT_USED);
     ASSERT_ARE_EQUAL(SEQ_NO_STATE, SEQ_NO_NOT_USED, seq_no_state, "sequence number already used at %" PRId64 "", seq_no);
     WakeByAddressSingle((PVOID)&chaos_test_context->seq_numbers[seq_no & TEST_SEQ_NO_QUEUE_SIZE]);
 }


### PR DESCRIPTION
- Improve hash table int tests to check that all sequence numbers are actually indicated
- Improve sorted list int tests to check that all sequence numbers are actually indicated
- Fix extraneous skipped seq no in insert/delete for sorted list