### PR TITLE
Add thread local hazard pointers helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/inc)
 
 set(clds_h_files
     ./inc/clds/clds_hazard_pointers.h
+    ./inc/clds/clds_hazard_pointers_thread_helper.h
     ./inc/clds/clds_sorted_list.h
     ./inc/clds/clds_st_hash_set.h
     ./inc/clds/lock_free_set.h
@@ -161,6 +162,7 @@ set(clds_h_files
 
 set(clds_c_files
     ./src/clds_hazard_pointers.c
+    ./src/clds_hazard_pointers_thread_helper.c
     ./src/clds_sorted_list.c
     ./src/clds_st_hash_set.c
     ./src/lock_free_set.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,6 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/inc)
 
 set(clds_h_files
     ./inc/clds/clds_hazard_pointers.h
-    ./inc/clds/clds_hazard_pointers_thread_helper.h
     ./inc/clds/clds_sorted_list.h
     ./inc/clds/clds_st_hash_set.h
     ./inc/clds/lock_free_set.h
@@ -160,9 +159,15 @@ set(clds_h_files
     ./inc/clds/mpsc_lock_free_queue.h
 )
 
+if (WIN32)
+    set(clds_h_files
+        ${clds_h_files}
+        ./inc/clds/clds_hazard_pointers_thread_helper.h # Windows only until there is a PAL for thread local storage
+    )
+endif()
+
 set(clds_c_files
     ./src/clds_hazard_pointers.c
-    ./src/clds_hazard_pointers_thread_helper.c
     ./src/clds_sorted_list.c
     ./src/clds_st_hash_set.c
     ./src/lock_free_set.c
@@ -170,6 +175,13 @@ set(clds_c_files
     ./src/clds_singly_linked_list.c
     ./src/mpsc_lock_free_queue.c
 )
+
+if (WIN32)
+    set(clds_c_files
+        ${clds_c_files}
+        ./src/clds_hazard_pointers_thread_helper.c # Windows only until there is a PAL for thread local storage
+    )
+endif()
 
 FILE(GLOB clds_md_files "devdoc/*.md")
 SOURCE_GROUP(devdoc FILES ${clds_md_files})

--- a/devdoc/clds_hazard_pointers_thread_helper_requirements.md
+++ b/devdoc/clds_hazard_pointers_thread_helper_requirements.md
@@ -1,0 +1,70 @@
+# `clds_hazard_pointers_thread_helper` Requirements
+
+## Overview
+
+This is a helper which handles storing and retrieving thread-local hazard pointers threads.
+
+## Exposed API
+
+```c
+typedef struct CLDS_HAZARD_POINTERS_THREAD_HELPER_TAG* CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE;
+
+MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, clds_hazard_pointers_thread_helper_create, CLDS_HAZARD_POINTERS_HANDLE, hazard_pointers);
+MOCKABLE_FUNCTION(, void, clds_hazard_pointers_thread_helper_destroy, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper);
+
+MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread_helper_get_thread, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper);
+```
+
+### clds_hazard_pointers_thread_helper_create
+
+```c
+MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, clds_hazard_pointers_thread_helper_create, CLDS_HAZARD_POINTERS_HANDLE, hazard_pointers);
+```
+
+`clds_hazard_pointers_thread_helper_create` initializes the thread-local state for using the hazard pointers and returns the handle to the helper. The `hazard_pointers` lifetime must be greater than or equal to this handle, as no reference counting is performed.
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_001: [** If `hazard_pointers` is `NULL` then `clds_hazard_pointers_thread_helper_create` shall fail and return `NULL`. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_002: [** `clds_hazard_pointers_thread_helper_create` shall allocate memory for the helper. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_003: [** `clds_hazard_pointers_thread_helper_create` shall allocate the thread local storage slot for the hazard pointers by calling `TlsAlloc`. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_004: [** `clds_hazard_pointers_thread_helper_create` shall succeed and return the helper. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_005: [** If there are any errors then `clds_hazard_pointers_thread_helper_create` shall fail and return `NULL`. **]**
+
+### clds_hazard_pointers_thread_helper_destroy
+
+```c
+MOCKABLE_FUNCTION(, void, clds_hazard_pointers_thread_helper_destroy, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper);
+```
+
+`clds_hazard_pointers_thread_helper_destroy` frees the resources from the create function.
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_006: [** If `hazard_pointers_helper` is `NULL` then `clds_hazard_pointers_thread_helper_destroy` shall return. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_007: [** `clds_hazard_pointers_thread_helper_destroy` shall free the thread local storage slot by calling `TlsFree`. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_008: [** `clds_hazard_pointers_thread_helper_destroy` shall free the helper. **]**
+
+### clds_hazard_pointers_thread_helper_get_thread
+
+```c
+MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread_helper_get_thread, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper);
+```
+
+`clds_hazard_pointers_thread_helper_get_thread` gets the `CLDS_HAZARD_POINTERS_THREAD_HANDLE` for the thread, using thread local storage to store or retrieve the handle if it has already been registered.
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_009: [** If `hazard_pointers_helper` is `NULL` then `clds_hazard_pointers_thread_helper_get_thread` shall fail and return `NULL`. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_010: [** `clds_hazard_pointers_thread_helper_get_thread` shall get the thread local handle by calling `TlsGetValue`. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_011: [** If no thread local handle exists then: **]**
+
+ - **SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_012: [** `clds_hazard_pointers_thread_helper_get_thread` shall create one by calling `clds_hazard_pointers_register_thread`. **]**
+
+ - **SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_013: [** `clds_hazard_pointers_thread_helper_get_thread` shall store the new handle by calling `TlsSetValue`. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_014: [** `clds_hazard_pointers_thread_helper_get_thread` shall return the thread local handle. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_015: [** If there are any errors then `clds_hazard_pointers_thread_helper_get_thread` shall fail and return `NULL`. **]**

--- a/inc/clds/clds_hazard_pointers_thread_helper.h
+++ b/inc/clds/clds_hazard_pointers_thread_helper.h
@@ -1,0 +1,25 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+#ifndef CLDS_HAZARD_POINTERS_THREAD_HELPER_H
+#define CLDS_HAZARD_POINTERS_THREAD_HELPER_H
+
+#include "macro_utils/macro_utils.h"
+
+#include "clds/clds_hazard_pointers.h"
+
+#include "umock_c/umock_c_prod.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct CLDS_HAZARD_POINTERS_THREAD_HELPER_TAG* CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE;
+
+MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, clds_hazard_pointers_thread_helper_create, CLDS_HAZARD_POINTERS_HANDLE, hazard_pointers);
+MOCKABLE_FUNCTION(, void, clds_hazard_pointers_thread_helper_destroy, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper);
+
+MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread_helper_get_thread, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CLDS_HAZARD_POINTERS_THREAD_HELPER_H

--- a/src/clds_hazard_pointers_thread_helper.c
+++ b/src/clds_hazard_pointers_thread_helper.c
@@ -1,0 +1,131 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#include "macro_utils/macro_utils.h"
+
+#include "windows.h" // Thread Local Storage doesn't have a PAL yet
+
+#include "c_logging/logger.h"
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#include "clds/clds_hazard_pointers.h"
+
+#include "clds/clds_hazard_pointers_thread_helper.h"
+
+typedef struct CLDS_HAZARD_POINTERS_THREAD_HELPER_TAG
+{
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers;
+    DWORD tls_slot;
+} CLDS_HAZARD_POINTERS_THREAD_HELPER;
+
+IMPLEMENT_MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, clds_hazard_pointers_thread_helper_create, CLDS_HAZARD_POINTERS_HANDLE, hazard_pointers)
+{
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE result;
+
+    if (hazard_pointers == NULL)
+    {
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_001: [ If hazard_pointers is NULL then clds_hazard_pointers_thread_helper_create shall fail and return NULL. ]*/
+        LogError("Invalid args: CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = %p", hazard_pointers);
+        result = NULL;
+    }
+    else
+    {
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_002: [ clds_hazard_pointers_thread_helper_create shall allocate memory for the helper. ]*/
+        result = malloc(sizeof(CLDS_HAZARD_POINTERS_THREAD_HELPER));
+
+        if (result == NULL)
+        {
+            /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_005: [ If there are any errors then clds_hazard_pointers_thread_helper_create shall fail and return NULL. ]*/
+            LogError("malloc CLDS_HAZARD_POINTERS_THREAD_HELPER failed");
+        }
+        else
+        {
+            /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_003: [ clds_hazard_pointers_thread_helper_create shall allocate the thread local storage slot for the hazard pointers by calling TlsAlloc. ]*/
+            result->tls_slot = TlsAlloc();
+
+            if (result->tls_slot == TLS_OUT_OF_INDEXES)
+            {
+                LogError("TlsAlloc failed");
+            }
+            else
+            {
+                /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_004: [ clds_hazard_pointers_thread_helper_create shall succeed and return the helper. ]*/
+                result->hazard_pointers = hazard_pointers;
+
+                goto all_ok;
+                //(void)TlsFree(result->tls_slot);
+            }
+
+            free(result);
+            result = NULL;
+        }
+    }
+all_ok:
+    return result;
+}
+
+IMPLEMENT_MOCKABLE_FUNCTION(, void, clds_hazard_pointers_thread_helper_destroy, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper)
+{
+    if (hazard_pointers_helper == NULL)
+    {
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_006: [ If hazard_pointers_helper is NULL then clds_hazard_pointers_thread_helper_destroy shall return. ]*/
+        LogError("Invalid args: CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE hazard_pointers_helper = %p", hazard_pointers_helper);
+    }
+    else
+    {
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_007: [ clds_hazard_pointers_thread_helper_destroy shall free the thread local storage slot by calling TlsFree. ]*/
+        (void)TlsFree(hazard_pointers_helper->tls_slot);
+
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_008: [ clds_hazard_pointers_thread_helper_destroy shall free the helper. ]*/
+        free(hazard_pointers_helper);
+    }
+}
+
+IMPLEMENT_MOCKABLE_FUNCTION(, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread_helper_get_thread, CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE, hazard_pointers_helper)
+{
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE result;
+
+    if (hazard_pointers_helper == NULL)
+    {
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_009: [ If hazard_pointers_helper is NULL then clds_hazard_pointers_thread_helper_get_thread shall fail and return NULL. ]*/
+        LogError("Invalid args: CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE hazard_pointers_helper = %p", hazard_pointers_helper);
+        result = NULL;
+    }
+    else
+    {
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_010: [ clds_hazard_pointers_thread_helper_get_thread shall get the thread local handle by calling TlsGetValue. ]*/
+        result = TlsGetValue(hazard_pointers_helper->tls_slot);
+        if (result == NULL)
+        {
+            /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_011: [ If no thread local handle exists then: ]*/
+
+            /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_012: [ clds_hazard_pointers_thread_helper_get_thread shall create one by calling clds_hazard_pointers_register_thread. ]*/
+            result = clds_hazard_pointers_register_thread(hazard_pointers_helper->hazard_pointers);
+            if (result == NULL)
+            {
+                /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_015: [ If there are any errors then clds_hazard_pointers_thread_helper_get_thread shall fail and return NULL. ]*/
+                LogError("Cannot create clds hazard pointers thread");
+            }
+            else
+            {
+                /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_013: [ clds_hazard_pointers_thread_helper_get_thread shall store the new handle by calling TlsSetValue. ]*/
+                if (!TlsSetValue(hazard_pointers_helper->tls_slot, result))
+                {
+                    /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_015: [ If there are any errors then clds_hazard_pointers_thread_helper_get_thread shall fail and return NULL. ]*/
+                    LogError("Cannot set Tls slot value");
+                }
+                else
+                {
+                    /*Codes_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_014: [ clds_hazard_pointers_thread_helper_get_thread shall return the thread local handle. ]*/
+                    goto all_ok;
+                }
+
+                clds_hazard_pointers_unregister_thread(result);
+                result = NULL;
+            }
+        }
+    }
+all_ok:
+    return result;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,9 @@ add_subdirectory(reals)
 #unittests
 if(${run_unittests})
     build_test_folder(reals_ut)
-    build_test_folder(clds_hazard_pointers_thread_helper_ut)
+    if(WIN32)
+        build_test_folder(clds_hazard_pointers_thread_helper_ut) # Windows only until there is a PAL for thread local storage
+    endif()
     build_test_folder(clds_hazard_pointers_ut)
     build_test_folder(clds_st_hash_set_ut)
     build_test_folder(lock_free_set_ut)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(reals)
 #unittests
 if(${run_unittests})
     build_test_folder(reals_ut)
+    build_test_folder(clds_hazard_pointers_thread_helper_ut)
     build_test_folder(clds_hazard_pointers_ut)
     build_test_folder(clds_st_hash_set_ut)
     build_test_folder(lock_free_set_ut)

--- a/tests/clds_hazard_pointers_thread_helper_ut/CMakeLists.txt
+++ b/tests/clds_hazard_pointers_thread_helper_ut/CMakeLists.txt
@@ -1,0 +1,17 @@
+#Copyright (c) Microsoft. All rights reserved.
+
+set(theseTestsName clds_hazard_pointers_thread_helper_ut)
+
+set(${theseTestsName}_test_files
+${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+clds_hazard_pointers_thread_helper_mocked.c
+)
+
+set(${theseTestsName}_h_files
+../../inc/clds/clds_hazard_pointers_thread_helper.h
+)
+
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal_umocktypes)

--- a/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_mocked.c
+++ b/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_mocked.c
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#define TlsAlloc mocked_TlsAlloc
+#define TlsFree mocked_TlsFree
+#define TlsGetValue mocked_TlsGetValue
+#define TlsSetValue mocked_TlsSetValue
+
+#include "../../src/clds_hazard_pointers_thread_helper.c"

--- a/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut.c
+++ b/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut.c
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#include <stdlib.h>
+#include <stddef.h>
+
+#include "windows.h"
+
+#include "macro_utils/macro_utils.h"
+
+#include "testrunnerswitcher.h"
+#include "umock_c/umock_c.h"
+#include "umock_c/umock_c_negative_tests.h"
+#include "umock_c/umocktypes.h"
+#include "umock_c/umocktypes_windows.h"
+
+#define ENABLE_MOCKS
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+#include "clds/clds_hazard_pointers.h"
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+
+#include "clds/clds_hazard_pointers_thread_helper.h"
+
+static DWORD default_tls_slot = 42;
+
+MOCK_FUNCTION_WITH_CODE(, DWORD, mocked_TlsAlloc)
+MOCK_FUNCTION_END(default_tls_slot)
+MOCK_FUNCTION_WITH_CODE(, BOOL, mocked_TlsFree, DWORD, dwTlsIndex)
+MOCK_FUNCTION_END(TRUE)
+MOCK_FUNCTION_WITH_CODE(, LPVOID, mocked_TlsGetValue, DWORD, dwTlsIndex)
+MOCK_FUNCTION_END(NULL)
+MOCK_FUNCTION_WITH_CODE(, BOOL, mocked_TlsSetValue, DWORD, dwTlsIndex, LPVOID, lpTlsValue)
+MOCK_FUNCTION_END(TRUE)
+
+static CLDS_HAZARD_POINTERS_HANDLE test_hazard_pointers = (CLDS_HAZARD_POINTERS_HANDLE)0x1234;
+static CLDS_HAZARD_POINTERS_THREAD_HANDLE test_hazard_pointers_thread = (CLDS_HAZARD_POINTERS_THREAD_HANDLE)0xabcd;
+
+static CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE test_create(void)
+{
+    STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(mocked_TlsAlloc());
+
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = clds_hazard_pointers_thread_helper_create(test_hazard_pointers);
+
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NOT_NULL(helper);
+
+    umock_c_reset_all_calls();
+
+    return helper;
+}
+
+static CLDS_HAZARD_POINTERS_THREAD_HANDLE test_get_thread(CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper)
+{
+    STRICT_EXPECTED_CALL(mocked_TlsGetValue(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_hazard_pointers_register_thread(test_hazard_pointers));
+    STRICT_EXPECTED_CALL(mocked_TlsSetValue(IGNORED_ARG, IGNORED_ARG));
+
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_thread_helper_get_thread(helper);
+
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
+
+    umock_c_reset_all_calls();
+
+    return hazard_pointers_thread;
+}
+
+MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
+
+static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
+{
+    ASSERT_FAIL("umock_c reported error :%" PRI_MU_ENUM "", MU_ENUM_VALUE(UMOCK_C_ERROR_CODE, error_code));
+}
+
+BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
+
+TEST_SUITE_INITIALIZE(suite_init)
+{
+    ASSERT_ARE_EQUAL(int, 0, real_gballoc_hl_init(NULL, NULL));
+
+    ASSERT_ARE_EQUAL(int, 0, umock_c_init(on_umock_c_error), "umock_c_init");
+    ASSERT_ARE_EQUAL(int, 0, umocktypes_windows_register_types(), "umocktypes_windows_register_types");
+
+    REGISTER_GBALLOC_HL_GLOBAL_MOCK_HOOK();
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(malloc, NULL);
+
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(mocked_TlsAlloc, TLS_OUT_OF_INDEXES);
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(mocked_TlsSetValue, FALSE);
+    REGISTER_GLOBAL_MOCK_RETURNS(clds_hazard_pointers_register_thread, test_hazard_pointers_thread, NULL);
+
+    REGISTER_UMOCK_ALIAS_TYPE(CLDS_HAZARD_POINTERS_HANDLE, void*);
+    REGISTER_UMOCK_ALIAS_TYPE(CLDS_HAZARD_POINTERS_THREAD_HANDLE, void*);
+
+    REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(mocked_TlsAlloc, mocked_TlsFree);
+}
+
+TEST_SUITE_CLEANUP(suite_cleanup)
+{
+    umock_c_deinit();
+
+    real_gballoc_hl_deinit();
+}
+
+TEST_FUNCTION_INITIALIZE(method_init)
+{
+    umock_c_reset_all_calls();
+    umock_c_negative_tests_init();
+
+}
+
+TEST_FUNCTION_CLEANUP(method_cleanup)
+{
+    umock_c_negative_tests_deinit();
+}
+
+//
+// clds_hazard_pointers_thread_helper_create
+//
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_001: [ If hazard_pointers is NULL then clds_hazard_pointers_thread_helper_create shall fail and return NULL. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_create_with_NULL_hazard_pointers_fails)
+{
+    // arrange
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = clds_hazard_pointers_thread_helper_create(NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NULL(helper);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_002: [ clds_hazard_pointers_thread_helper_create shall allocate memory for the helper. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_003: [ clds_hazard_pointers_thread_helper_create shall allocate the thread local storage slot for the hazard pointers by calling TlsAlloc. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_004: [ clds_hazard_pointers_thread_helper_create shall succeed and return the helper. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_create_succeeds)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(mocked_TlsAlloc());
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = clds_hazard_pointers_thread_helper_create(test_hazard_pointers);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NOT_NULL(helper);
+
+    // cleanup
+    clds_hazard_pointers_thread_helper_destroy(helper);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_005: [ If there are any errors then clds_hazard_pointers_thread_helper_create shall fail and return NULL. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_create_fails_when_underlying_functions_fail)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(malloc(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(mocked_TlsAlloc());
+
+    umock_c_negative_tests_snapshot();
+
+    for (size_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+    {
+        if (umock_c_negative_tests_can_call_fail(i))
+        {
+            umock_c_negative_tests_reset();
+            umock_c_negative_tests_fail_call(i);
+
+            // act
+            CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = clds_hazard_pointers_thread_helper_create(test_hazard_pointers);
+
+            // assert
+            ASSERT_IS_NULL(helper);
+        }
+    }
+}
+
+//
+// clds_hazard_pointers_thread_helper_destroy
+//
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_006: [ If hazard_pointers_helper is NULL then clds_hazard_pointers_thread_helper_destroy shall return. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_destroy_with_NULL_hazard_pointers_helper_returns)
+{
+    // arrange
+
+    // act
+    clds_hazard_pointers_thread_helper_destroy(NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_007: [ clds_hazard_pointers_thread_helper_destroy shall free the thread local storage slot by calling TlsFree. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_008: [ clds_hazard_pointers_thread_helper_destroy shall free the helper. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_destroy_frees_resources)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = test_create();
+
+    STRICT_EXPECTED_CALL(mocked_TlsFree(default_tls_slot));
+    STRICT_EXPECTED_CALL(free(IGNORED_ARG));
+
+    // act
+    clds_hazard_pointers_thread_helper_destroy(helper);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+//
+// clds_hazard_pointers_thread_helper_get_thread
+//
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_009: [ If hazard_pointers_helper is NULL then clds_hazard_pointers_thread_helper_get_thread shall fail and return NULL. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_get_thread_with_NULL_hazard_pointers_helper_fails)
+{
+    // arrange
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_thread_helper_get_thread(NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NULL(hazard_pointers_thread);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_010: [ clds_hazard_pointers_thread_helper_get_thread shall get the thread local handle by calling TlsGetValue. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_011: [ If no thread local handle exists then: ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_012: [ clds_hazard_pointers_thread_helper_get_thread shall create one by calling clds_hazard_pointers_register_thread. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_013: [ clds_hazard_pointers_thread_helper_get_thread shall store the new handle by calling TlsSetValue. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_014: [ clds_hazard_pointers_thread_helper_get_thread shall return the thread local handle. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_get_thread_first_time_succeeds)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = test_create();
+
+    STRICT_EXPECTED_CALL(mocked_TlsGetValue(default_tls_slot));
+    STRICT_EXPECTED_CALL(clds_hazard_pointers_register_thread(test_hazard_pointers));
+    STRICT_EXPECTED_CALL(mocked_TlsSetValue(default_tls_slot, test_hazard_pointers_thread));
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_thread_helper_get_thread(helper);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
+
+    // cleanup
+    clds_hazard_pointers_thread_helper_destroy(helper);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_010: [ clds_hazard_pointers_thread_helper_get_thread shall get the thread local handle by calling TlsGetValue. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_014: [ clds_hazard_pointers_thread_helper_get_thread shall return the thread local handle. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_get_thread_second_time_succeeds)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = test_create();
+    (void)test_get_thread(helper);
+
+    STRICT_EXPECTED_CALL(mocked_TlsGetValue(default_tls_slot))
+        .SetReturn((void*)test_hazard_pointers_thread);
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_thread_helper_get_thread(helper);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
+
+    // cleanup
+    clds_hazard_pointers_thread_helper_destroy(helper);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_010: [ clds_hazard_pointers_thread_helper_get_thread shall get the thread local handle by calling TlsGetValue. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_014: [ clds_hazard_pointers_thread_helper_get_thread shall return the thread local handle. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_get_thread_second_time_succeeds_creates_new_when_different_thread)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = test_create();
+    (void)test_get_thread(helper);
+
+    STRICT_EXPECTED_CALL(mocked_TlsGetValue(default_tls_slot));
+    STRICT_EXPECTED_CALL(clds_hazard_pointers_register_thread(test_hazard_pointers));
+    STRICT_EXPECTED_CALL(mocked_TlsSetValue(default_tls_slot, test_hazard_pointers_thread));
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_thread_helper_get_thread(helper);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
+
+    // cleanup
+    clds_hazard_pointers_thread_helper_destroy(helper);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_015: [ If there are any errors then clds_hazard_pointers_thread_helper_get_thread shall fail and return NULL. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_get_thread_fails_when_clds_hazard_pointers_register_thread_fails)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = test_create();
+
+    STRICT_EXPECTED_CALL(mocked_TlsGetValue(default_tls_slot));
+    STRICT_EXPECTED_CALL(clds_hazard_pointers_register_thread(test_hazard_pointers))
+        .SetReturn(NULL);
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_thread_helper_get_thread(helper);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NULL(hazard_pointers_thread);
+
+    // cleanup
+    clds_hazard_pointers_thread_helper_destroy(helper);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_THREAD_HELPER_42_015: [ If there are any errors then clds_hazard_pointers_thread_helper_get_thread shall fail and return NULL. ]*/
+TEST_FUNCTION(clds_hazard_pointers_thread_helper_get_thread_fails_when_TlsSetValue_fails)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_THREAD_HELPER_HANDLE helper = test_create();
+
+    STRICT_EXPECTED_CALL(mocked_TlsGetValue(default_tls_slot));
+    STRICT_EXPECTED_CALL(clds_hazard_pointers_register_thread(test_hazard_pointers));
+    STRICT_EXPECTED_CALL(mocked_TlsSetValue(default_tls_slot, test_hazard_pointers_thread))
+        .SetReturn(FALSE);
+    STRICT_EXPECTED_CALL(clds_hazard_pointers_unregister_thread(test_hazard_pointers_thread));
+
+    // act
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_thread_helper_get_thread(helper);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+    ASSERT_IS_NULL(hazard_pointers_thread);
+
+    // cleanup
+    clds_hazard_pointers_thread_helper_destroy(helper);
+}
+
+END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)


### PR DESCRIPTION
Small helper for using thread local storage with hazard pointers. Note that this relies on Windows Tls API's currently (but could use a PAL version in the future)