### PR TITLE
Fix and re-enable clds_hash_table_perf

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -283,13 +283,12 @@ jobs:
       configuration: RelWithDebInfo
       maximumCpuCount: true
 
-# Fails for some reason, tracked by task
-#  - script: |
-#     echo Running Hash table perf test
-#     $(Build.Repository.LocalPath)/build_x64/RelWithDebInfo/clds_hash_table_perf.exe
-#
-#    workingDirectory: 'build_x64'
-#    displayName: 'Run clds_hash_table_perf tests'
+  - script: |
+     echo Running Hash table perf test
+     $(Build.Repository.LocalPath)/build_x64/RelWithDebInfo/clds_hash_table_perf.exe
+
+    workingDirectory: 'build_x64'
+    displayName: 'Run clds_hash_table_perf tests'
 
   - script: |
      echo Running Singly linked list perf test

--- a/devdoc/clds_hash_table_requirements.md
+++ b/devdoc/clds_hash_table_requirements.md
@@ -438,6 +438,8 @@ static void on_sorted_list_skipped_seq_no(void* context, int64_t skipped_sequenc
 
 **SRS_CLDS_HASH_TABLE_01_075: [** `on_sorted_list_skipped_seq_no` called with NULL `context` shall return. **]**
 
+**SRS_CLDS_HASH_TABLE_01_113: [** If the sequence number callback passed to `clds_hash_table_create` was `NULL`, `on_sorted_list_skipped_seq_no` shall return. **]**
+
 **SRS_CLDS_HASH_TABLE_01_076: [** `on_sorted_list_skipped_seq_no` shall call the skipped sequence number callback passed to `clds_hash_table_create` and pass the `skipped_sequence_no` as `skipped_sequence_no` argument. **]**
 
 ### clds_hash_table_snapshot

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -127,10 +127,14 @@ static void on_sorted_list_skipped_seq_no(void* context, int64_t skipped_sequenc
     }
     else
     {
-        /* Codes_SRS_CLDS_HASH_TABLE_01_076: [ on_sorted_list_skipped_seq_no shall call the skipped sequence number callback passed to clds_hash_table_create and pass the skipped_sequence_no as skipped_sequence_no argument. ]*/
         CLDS_HASH_TABLE_HANDLE clds_hash_table = context;
-        if (clds_hash_table->skipped_seq_no_cb != NULL)
+        if (clds_hash_table->skipped_seq_no_cb == NULL)
         {
+            /* Codes_SRS_CLDS_HASH_TABLE_01_113: [ If the sequence number callback passed to clds_hash_table_create was NULL, on_sorted_list_skipped_seq_no shall return. ]*/
+        }
+        else
+        {
+            /* Codes_SRS_CLDS_HASH_TABLE_01_076: [ on_sorted_list_skipped_seq_no shall call the skipped sequence number callback passed to clds_hash_table_create and pass the skipped_sequence_no as skipped_sequence_no argument. ]*/
             clds_hash_table->skipped_seq_no_cb(clds_hash_table->skipped_seq_no_cb_context, skipped_sequence_no);
         }
     }

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -129,7 +129,10 @@ static void on_sorted_list_skipped_seq_no(void* context, int64_t skipped_sequenc
     {
         /* Codes_SRS_CLDS_HASH_TABLE_01_076: [ on_sorted_list_skipped_seq_no shall call the skipped sequence number callback passed to clds_hash_table_create and pass the skipped_sequence_no as skipped_sequence_no argument. ]*/
         CLDS_HASH_TABLE_HANDLE clds_hash_table = context;
-        clds_hash_table->skipped_seq_no_cb(clds_hash_table->skipped_seq_no_cb_context, skipped_sequence_no);
+        if (clds_hash_table->skipped_seq_no_cb != NULL)
+        {
+            clds_hash_table->skipped_seq_no_cb(clds_hash_table->skipped_seq_no_cb_context, skipped_sequence_no);
+        }
     }
 }
 

--- a/tests/clds_hash_table_ut/clds_hash_table_ut.c
+++ b/tests/clds_hash_table_ut/clds_hash_table_ut.c
@@ -175,6 +175,30 @@ TEST_FUNCTION_CLEANUP(method_cleanup)
 {
 }
 
+typedef struct CLDS_HASH_TABLE_TEST_CONTEXT_TAG
+{
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers;
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread;
+    volatile_atomic int64_t start_seq_no;
+} CLDS_HASH_TABLE_TEST_CONTEXT;
+
+static void setup_test_context(CLDS_HASH_TABLE_TEST_CONTEXT* test_context)
+{
+    test_context->hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(test_context->hazard_pointers);
+    test_context->hazard_pointers_thread = clds_hazard_pointers_register_thread(test_context->hazard_pointers);
+    ASSERT_IS_NOT_NULL(test_context->hazard_pointers_thread);
+
+    (void)interlocked_exchange_64(&test_context->start_seq_no, 0);
+
+    umock_c_reset_all_calls();
+}
+
+static void destroy_test_context(CLDS_HASH_TABLE_TEST_CONTEXT* test_context)
+{
+    clds_hazard_pointers_destroy(test_context->hazard_pointers);
+}
+
 /* clds_hash_table_create */
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_001: [ clds_hash_table_create shall create a new hash table object and on success it shall return a non-NULL handle to the newly created hash table. ]*/
@@ -507,8 +531,7 @@ TEST_FUNCTION(clds_hash_table_destroy_frees_the_hash_table_resources)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(free(IGNORED_ARG));
@@ -549,23 +572,22 @@ TEST_FUNCTION(clds_hash_table_destroy_with_NULL_hash_table_returns)
 TEST_FUNCTION(clds_hash_table_insert_inserts_one_key_value_pair)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_INSERT_RESULT result;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item, NULL))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -573,31 +595,30 @@ TEST_FUNCTION(clds_hash_table_insert_inserts_one_key_value_pair)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_071: [ When a new list is created, the start sequence number passed to clds_hash_tabel_create shall be passed as the start_sequence_number argument. ]*/
 TEST_FUNCTION(clds_hash_table_insert_inserts_one_key_value_pair_with_non_NULL_start_sequence_no)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_INSERT_RESULT result;
     volatile_atomic int64_t sequence_number = 42;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &sequence_number, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &sequence_number, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, &sequence_number, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, &sequence_number, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item, NULL))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -605,21 +626,21 @@ TEST_FUNCTION(clds_hash_table_insert_inserts_one_key_value_pair_with_non_NULL_st
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_010: [ If clds_hash_table is NULL, clds_hash_table_insert shall fail and return CLDS_HASH_TABLE_INSERT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_insert_with_NULL_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_INSERT_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_insert(NULL, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_insert(NULL, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -627,7 +648,7 @@ TEST_FUNCTION(clds_hash_table_insert_with_NULL_hash_table_fails)
 
     // cleanup
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    clds_hazard_pointers_destroy(test_context.hazard_pointers);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_012: [ If clds_hazard_pointers_thread is NULL, clds_hash_table_insert shall fail and return CLDS_HASH_TABLE_INSERT_ERROR. ]*/
@@ -635,10 +656,9 @@ TEST_FUNCTION(clds_hash_table_insert_with_NULL_clds_hazard_pointers_thread_fails
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HASH_TABLE_HANDLE hash_table;
     CLDS_HASH_TABLE_INSERT_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     // act
@@ -658,16 +678,15 @@ TEST_FUNCTION(clds_hash_table_insert_with_NULL_clds_hazard_pointers_thread_fails
 TEST_FUNCTION(clds_hash_table_insert_with_NULL_key_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_INSERT_RESULT result;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, NULL, item, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, NULL, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -676,27 +695,26 @@ TEST_FUNCTION(clds_hash_table_insert_with_NULL_key_fails)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_022: [ If any error is encountered while inserting the key/value pair, clds_hash_table_insert shall fail and return CLDS_HASH_TABLE_INSERT_ERROR. ]*/
 TEST_FUNCTION(when_creating_the_singly_linked_list_fails_clds_hash_table_insert_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_INSERT_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
         .SetReturn(NULL);
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -705,28 +723,27 @@ TEST_FUNCTION(when_creating_the_singly_linked_list_fails_clds_hash_table_insert_
     // cleanup
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_022: [ If any error is encountered while inserting the key/value pair, clds_hash_table_insert shall fail and return CLDS_HASH_TABLE_INSERT_ERROR. ]*/
 TEST_FUNCTION(when_inserting_the_singly_linked_list_item_fails_clds_hash_table_insert_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_INSERT_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item, NULL))
         .SetReturn(CLDS_SORTED_LIST_INSERT_ERROR);
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -735,7 +752,7 @@ TEST_FUNCTION(when_inserting_the_singly_linked_list_item_fails_clds_hash_table_i
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_009: [ On success clds_hash_table_insert shall return CLDS_HASH_TABLE_INSERT_OK. ]*/
@@ -746,18 +763,17 @@ TEST_FUNCTION(when_inserting_the_singly_linked_list_item_fails_clds_hash_table_i
 TEST_FUNCTION(clds_hash_table_insert_with_2nd_key_on_the_same_bucket_does_not_create_another_list)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_INSERT_RESULT result;
     uint64_t first_hash;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1))
         .CaptureReturn(&first_hash);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -767,7 +783,7 @@ TEST_FUNCTION(clds_hash_table_insert_with_2nd_key_on_the_same_bucket_does_not_cr
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item_2, NULL));
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -775,7 +791,7 @@ TEST_FUNCTION(clds_hash_table_insert_with_2nd_key_on_the_same_bucket_does_not_cr
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_009: [ On success clds_hash_table_insert shall return CLDS_HASH_TABLE_INSERT_OK. ]*/
@@ -786,25 +802,24 @@ TEST_FUNCTION(clds_hash_table_insert_with_2nd_key_on_the_same_bucket_does_not_cr
 TEST_FUNCTION(clds_hash_table_insert_with_2nd_key_on_a_different_bucket_creates_another_list)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_INSERT_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 4, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 4, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x2));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item_2, NULL))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -812,22 +827,21 @@ TEST_FUNCTION(clds_hash_table_insert_with_2nd_key_on_a_different_bucket_creates_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_030: [ If the number of items in the list reaches the number of buckets, the number of buckets shall be doubled. ]*/
 TEST_FUNCTION(clds_hash_table_insert_when_the_number_of_items_reaches_number_of_buckets_allocates_another_bucket_array)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_INSERT_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -835,14 +849,14 @@ TEST_FUNCTION(clds_hash_table_insert_when_the_number_of_items_reaches_number_of_
 
     STRICT_EXPECTED_CALL(malloc_flex(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x2));
-    STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, hazard_pointers_thread, (void*)0x2));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, test_context.hazard_pointers_thread, (void*)0x2));
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
-    STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, hazard_pointers_thread, (CLDS_SORTED_LIST_ITEM*)item_2, NULL))
+    STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, test_context.hazard_pointers_thread, (CLDS_SORTED_LIST_ITEM*)item_2, NULL))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -850,22 +864,21 @@ TEST_FUNCTION(clds_hash_table_insert_when_the_number_of_items_reaches_number_of_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_046: [ If the key already exists in the hash table, clds_hash_table_insert shall fail and return CLDS_HASH_TABLE_INSERT_ALREADY_EXISTS. ]*/
 TEST_FUNCTION(clds_hash_table_insert_with_the_same_key_2_times_returns_KEY_ALREADY_EXISTS)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_INSERT_RESULT result;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -875,7 +888,7 @@ TEST_FUNCTION(clds_hash_table_insert_with_the_same_key_2_times_returns_KEY_ALREA
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item_2, NULL));
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_2, NULL);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_2, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -884,32 +897,31 @@ TEST_FUNCTION(clds_hash_table_insert_with_the_same_key_2_times_returns_KEY_ALREA
     // cleanup
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_2);
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_059: [ For each insert the order of the operation shall be computed by passing sequence_number to clds_sorted_list_insert. ]*/
 TEST_FUNCTION(clds_hash_table_insert_passes_the_sequence_number_to_the_sorted_list_insert)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_INSERT_RESULT result;
     volatile_atomic int64_t sequence_number = 42;
     int64_t insert_seq_no = 0;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &sequence_number, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &sequence_number, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, &sequence_number, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, &sequence_number, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item, &insert_seq_no))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, &insert_seq_no);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, &insert_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -918,24 +930,23 @@ TEST_FUNCTION(clds_hash_table_insert_passes_the_sequence_number_to_the_sorted_li
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_062: [ If the sequence_number argument is non-NULL, but no start sequence number was specified in clds_hash_table_create, clds_hash_table_insert shall fail and return CLDS_HASH_TABLE_INSERT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_insert_with_non_NULL_sequence_no_but_NULL_start_sequence_no_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_INSERT_RESULT result;
     int64_t insert_seq_no = 0;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, &insert_seq_no);
+    result = clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, &insert_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -944,7 +955,7 @@ TEST_FUNCTION(clds_hash_table_insert_with_non_NULL_sequence_no_but_NULL_start_se
     // cleanup
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* clds_hash_table_delete */
@@ -955,13 +966,12 @@ TEST_FUNCTION(clds_hash_table_insert_with_non_NULL_sequence_no_but_NULL_start_se
 TEST_FUNCTION(clds_hash_table_delete_deletes_the_key)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -969,11 +979,11 @@ TEST_FUNCTION(clds_hash_table_delete_deletes_the_key)
     STRICT_EXPECTED_CALL(clds_hazard_pointers_reclaim(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_delete_key(IGNORED_ARG, hazard_pointers_thread, (void*)0x1, NULL));
+    STRICT_EXPECTED_CALL(clds_sorted_list_delete_key(IGNORED_ARG, test_context.hazard_pointers_thread, (void*)0x1, NULL));
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -981,40 +991,38 @@ TEST_FUNCTION(clds_hash_table_delete_deletes_the_key)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_015: [ If clds_hash_table is NULL, clds_hash_table_delete shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_with_NULL_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
-    umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_delete(NULL, hazard_pointers_thread, (void*)0x1, NULL);
+    result = clds_hash_table_delete(NULL, test_context.hazard_pointers_thread, (void*)0x1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_NOT_EQUAL(int, 0, result);
 
     // cleanup
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_017: [ If clds_hazard_pointers_thread is NULL, clds_hash_table_delete shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_with_NULL_clds_hazard_pointers_thread_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
@@ -1026,24 +1034,23 @@ TEST_FUNCTION(clds_hash_table_delete_with_NULL_clds_hazard_pointers_thread_fails
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_016: [ If key is NULL, clds_hash_table_delete shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_with_NULL_key_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, NULL, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, NULL, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1051,24 +1058,23 @@ TEST_FUNCTION(clds_hash_table_delete_with_NULL_key_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_023: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_delete shall return CLDS_HASH_TABLE_DELETE_NOT_FOUND. ]*/
 TEST_FUNCTION(clds_hash_table_delete_with_a_key_that_is_not_in_the_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1076,27 +1082,26 @@ TEST_FUNCTION(clds_hash_table_delete_with_a_key_that_is_not_in_the_hash_table_fa
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_023: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_delete shall return CLDS_HASH_TABLE_DELETE_NOT_FOUND. ]*/
 TEST_FUNCTION(clds_hash_table_delete_with_a_key_that_is_already_deleted_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
-    (void)clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
+    (void)clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1104,20 +1109,19 @@ TEST_FUNCTION(clds_hash_table_delete_with_a_key_that_is_already_deleted_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_024: [ If a bucket is identified and the delete of the item from the underlying list fails, clds_hash_table_delete shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_delete_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
@@ -1125,7 +1129,7 @@ TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_delete_
         .SetReturn(CLDS_SORTED_LIST_DELETE_ERROR);
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1133,7 +1137,7 @@ TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_delete_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_101: [ Otherwise, key shall be looked up in each of the arrays of buckets starting with the first. ]*/
@@ -1141,15 +1145,14 @@ TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_delete_
 TEST_FUNCTION(delete_looks_in_2_buckets)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1161,7 +1164,7 @@ TEST_FUNCTION(delete_looks_in_2_buckets)
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1169,7 +1172,7 @@ TEST_FUNCTION(delete_looks_in_2_buckets)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_101: [ Otherwise, key shall be looked up in each of the arrays of buckets starting with the first. ]*/
@@ -1177,9 +1180,8 @@ TEST_FUNCTION(delete_looks_in_2_buckets)
 TEST_FUNCTION(delete_looks_in_3_buckets)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     // 1st bucket array has 1 bucket
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
@@ -1188,11 +1190,11 @@ TEST_FUNCTION(delete_looks_in_3_buckets)
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     // 3rd bucket array has 4 buckets
     CLDS_HASH_TABLE_ITEM* item_4 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x4, item_4, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x4, item_4, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1205,7 +1207,7 @@ TEST_FUNCTION(delete_looks_in_3_buckets)
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1213,22 +1215,21 @@ TEST_FUNCTION(delete_looks_in_3_buckets)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_023: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_delete shall return CLDS_HASH_TABLE_DELETE_NOT_FOUND. ]*/
 TEST_FUNCTION(when_item_is_not_found_in_any_bucket_delete_returns_NOT_FOUND)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1239,7 +1240,7 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_delete_returns_NOT_FOUND)
     STRICT_EXPECTED_CALL(clds_sorted_list_delete_key(IGNORED_ARG, IGNORED_ARG, (void*)0x3, NULL));
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x3, NULL);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x3, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1247,22 +1248,21 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_delete_returns_NOT_FOUND)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_063: [ For each delete the order of the operation shall be computed by passing sequence_number to clds_sorted_list_delete_key. ]*/
 TEST_FUNCTION(clds_hash_table_delete_deletes_the_key_and_stamps_the_sequence_no)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     volatile_atomic int64_t sequence_number = 42;
     int64_t delete_seq_no = 0;
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &sequence_number, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &sequence_number, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1270,11 +1270,11 @@ TEST_FUNCTION(clds_hash_table_delete_deletes_the_key_and_stamps_the_sequence_no)
     STRICT_EXPECTED_CALL(clds_hazard_pointers_reclaim(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_delete_key(IGNORED_ARG, hazard_pointers_thread, (void*)0x1, &delete_seq_no));
+    STRICT_EXPECTED_CALL(clds_sorted_list_delete_key(IGNORED_ARG, test_context.hazard_pointers_thread, (void*)0x1, &delete_seq_no));
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, &delete_seq_no);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &delete_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1283,25 +1283,24 @@ TEST_FUNCTION(clds_hash_table_delete_deletes_the_key_and_stamps_the_sequence_no)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_066: [ If the sequence_number argument is non-NULL, but no start sequence number was specified in clds_hash_table_create, clds_hash_table_delete shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_with_non_NULL_sequence_no_but_NULL_start_sequence_number_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int64_t delete_seq_no = 0;
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, &delete_seq_no);
+    result = clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &delete_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1309,7 +1308,7 @@ TEST_FUNCTION(clds_hash_table_delete_with_non_NULL_sequence_no_but_NULL_start_se
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* clds_hash_table_delete_key_value */
@@ -1320,13 +1319,12 @@ TEST_FUNCTION(clds_hash_table_delete_with_non_NULL_sequence_no_but_NULL_start_se
 TEST_FUNCTION(clds_hash_table_delete_key_value_deletes_the_key)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1334,11 +1332,11 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_deletes_the_key)
     STRICT_EXPECTED_CALL(clds_hazard_pointers_reclaim(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_delete_item(IGNORED_ARG, hazard_pointers_thread, (CLDS_SORTED_LIST_ITEM*)item, NULL));
+    STRICT_EXPECTED_CALL(clds_sorted_list_delete_item(IGNORED_ARG, test_context.hazard_pointers_thread, (CLDS_SORTED_LIST_ITEM*)item, NULL));
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1346,21 +1344,21 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_deletes_the_key)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_003: [ If clds_hash_table is NULL, clds_hash_table_delete_key_value shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_delete_key_value(NULL, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_delete_key_value(NULL, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1368,20 +1366,19 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_hash_table_fails)
 
     // cleanup
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_004: [ If clds_hazard_pointers_thread is NULL, clds_hash_table_delete_key_value shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_clds_hazard_pointers_thread_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
@@ -1393,24 +1390,23 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_clds_hazard_pointers_th
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_005: [ If key is NULL, clds_hash_table_delete_key_value shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_key_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, NULL, item, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, NULL, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1418,24 +1414,23 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_key_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_006: [ If value is NULL, clds_hash_table_delete_key_value shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_value_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, NULL, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1443,25 +1438,24 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_NULL_value_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_008: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_delete_key_value shall return CLDS_HASH_TABLE_DELETE_NOT_FOUND. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_with_a_key_that_is_not_in_the_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1470,27 +1464,26 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_a_key_that_is_not_in_the_has
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_008: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_delete_key_value shall return CLDS_HASH_TABLE_DELETE_NOT_FOUND. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_with_a_key_that_is_already_deleted_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
-    (void)clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
+    (void)clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1498,20 +1491,19 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_a_key_that_is_already_delete
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_009: [ If a bucket is identified and the delete of the item from the underlying list fails, clds_hash_table_delete_key_value shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_delete_key_value_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
@@ -1519,7 +1511,7 @@ TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_delete_
         .SetReturn(CLDS_SORTED_LIST_DELETE_ERROR);
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1527,24 +1519,22 @@ TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_delete_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
-
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_007: [ Otherwise, key shall be looked up in each of the arrays of buckets starting with the first. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_010: [ If the element to be deleted is not found in an array of buckets, then clds_hash_table_delete_key_value shall look in the next available array of buckets. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_2_buckets)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1556,7 +1546,7 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_2_buckets)
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1564,7 +1554,7 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_2_buckets)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_007: [ Otherwise, key shall be looked up in each of the arrays of buckets starting with the first. ]*/
@@ -1572,9 +1562,8 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_2_buckets)
 TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_3_buckets)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     // 1st bucket array has 1 bucket
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
@@ -1583,11 +1572,11 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_3_buckets)
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     // 3rd bucket array has 4 buckets
     CLDS_HASH_TABLE_ITEM* item_4 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x4, item_4, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x4, item_4, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1600,7 +1589,7 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_3_buckets)
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1608,23 +1597,22 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_looks_in_3_buckets)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_008: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_delete_key_value shall return CLDS_HASH_TABLE_DELETE_NOT_FOUND. ]*/
 TEST_FUNCTION(when_item_is_not_found_in_any_bucket_clds_hash_table_delete_key_value_returns_NOT_FOUND)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1635,7 +1623,7 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_clds_hash_table_delete_key_va
     STRICT_EXPECTED_CALL(clds_sorted_list_delete_item(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item_3, NULL));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1644,7 +1632,7 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_clds_hash_table_delete_key_va
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_3);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 
@@ -1652,16 +1640,15 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_clds_hash_table_delete_key_va
 TEST_FUNCTION(when_item_is_not_found_in_any_bucket_clds_hash_table_delete_key_value_returns_NOT_FOUND_even_when_key_is_found_but_different_value)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1672,7 +1659,7 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_clds_hash_table_delete_key_va
     STRICT_EXPECTED_CALL(clds_sorted_list_delete_item(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item_3, NULL));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item_3, NULL);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_3, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1681,22 +1668,21 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_clds_hash_table_delete_key_va
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_3);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_011: [ For each delete the order of the operation shall be computed by passing sequence_number to clds_sorted_list_delete_item. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_deletes_the_key_and_stamps_the_sequence_no)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     volatile_atomic int64_t sequence_number = 42;
     int64_t delete_seq_no = 0;
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &sequence_number, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &sequence_number, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1704,11 +1690,11 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_deletes_the_key_and_stamps_the_se
     STRICT_EXPECTED_CALL(clds_hazard_pointers_reclaim(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_delete_item(IGNORED_ARG, hazard_pointers_thread, (CLDS_SORTED_LIST_ITEM*)item, &delete_seq_no));
+    STRICT_EXPECTED_CALL(clds_sorted_list_delete_item(IGNORED_ARG, test_context.hazard_pointers_thread, (CLDS_SORTED_LIST_ITEM*)item, &delete_seq_no));
     STRICT_EXPECTED_CALL(test_item_cleanup_func((void*)0x4242, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item, &delete_seq_no);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, &delete_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1717,25 +1703,24 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_deletes_the_key_and_stamps_the_se
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_012: [ If the sequence_number argument is non-NULL, but no start sequence number was specified in clds_hash_table_create, clds_hash_table_delete_key_value shall fail and return CLDS_HASH_TABLE_DELETE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_delete_key_value_with_non_NULL_sequence_no_but_NULL_start_sequence_number_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     int64_t delete_seq_no = 0;
     CLDS_HASH_TABLE_DELETE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_delete_key_value(hash_table, hazard_pointers_thread, (void*)0x1, item, &delete_seq_no);
+    result = clds_hash_table_delete_key_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, &delete_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1743,7 +1728,7 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_non_NULL_sequence_no_but_NUL
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* clds_hash_table_remove */
@@ -1755,14 +1740,13 @@ TEST_FUNCTION(clds_hash_table_delete_key_value_with_non_NULL_sequence_no_but_NUL
 TEST_FUNCTION(clds_hash_table_remove_removes_the_key_from_the_list)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1770,10 +1754,10 @@ TEST_FUNCTION(clds_hash_table_remove_removes_the_key_from_the_list)
     STRICT_EXPECTED_CALL(clds_hazard_pointers_reclaim(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_remove_key(IGNORED_ARG, hazard_pointers_thread, (void*)0x1, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_remove_key(IGNORED_ARG, test_context.hazard_pointers_thread, (void*)0x1, IGNORED_ARG, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1782,23 +1766,22 @@ TEST_FUNCTION(clds_hash_table_remove_removes_the_key_from_the_list)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, removed_item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_067: [ For each remove the order of the operation shall be computed by passing sequence_number to clds_sorted_list_remove_key. ]*/
 TEST_FUNCTION(clds_hash_table_remove_removes_the_key_from_the_list_with_non_NULL_sequence_no)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
     volatile_atomic int64_t sequence_number = 42;
     int64_t remove_seq_no;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &sequence_number, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &sequence_number, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -1806,10 +1789,10 @@ TEST_FUNCTION(clds_hash_table_remove_removes_the_key_from_the_list_with_non_NULL
     STRICT_EXPECTED_CALL(clds_hazard_pointers_reclaim(IGNORED_ARG, IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_remove_key(IGNORED_ARG, hazard_pointers_thread, (void*)0x1, IGNORED_ARG, &remove_seq_no));
+    STRICT_EXPECTED_CALL(clds_sorted_list_remove_key(IGNORED_ARG, test_context.hazard_pointers_thread, (void*)0x1, IGNORED_ARG, &remove_seq_no));
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, &remove_seq_no);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, &remove_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1819,42 +1802,40 @@ TEST_FUNCTION(clds_hash_table_remove_removes_the_key_from_the_list_with_non_NULL
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, removed_item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_050: [ If clds_hash_table is NULL, clds_hash_table_remove shall fail and return CLDS_HASH_TABLE_REMOVE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_remove_with_NULL_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* removed_item;
-    umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_remove(NULL, hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
+    result = clds_hash_table_remove(NULL, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_REMOVE_RESULT, CLDS_HASH_TABLE_REMOVE_ERROR, result);
 
     // cleanup
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_052: [ If clds_hazard_pointers_thread is NULL, clds_hash_table_remove shall fail and return CLDS_HASH_TABLE_REMOVE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_remove_with_NULL_clds_hazard_pointers_thread_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
@@ -1866,25 +1847,24 @@ TEST_FUNCTION(clds_hash_table_remove_with_NULL_clds_hazard_pointers_thread_fails
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_051: [ If key is NULL, clds_hash_table_remove shall fail and return CLDS_HASH_TABLE_REMOVE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_remove_with_NULL_key_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, NULL, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, NULL, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1892,24 +1872,23 @@ TEST_FUNCTION(clds_hash_table_remove_with_NULL_key_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_056: [ If item is NULL, clds_hash_table_remove shall fail and return CLDS_HASH_TABLE_REMOVE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_remove_with_NULL_item_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, NULL, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1917,25 +1896,24 @@ TEST_FUNCTION(clds_hash_table_remove_with_NULL_item_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_053: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_remove shall return CLDS_HASH_TABLE_REMOVE_NOT_FOUND. ]*/
 TEST_FUNCTION(clds_hash_table_remove_with_a_key_that_is_not_in_the_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1943,28 +1921,27 @@ TEST_FUNCTION(clds_hash_table_remove_with_a_key_that_is_not_in_the_hash_table_fa
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_053: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_remove shall return CLDS_HASH_TABLE_REMOVE_NOT_FOUND. ]*/
 TEST_FUNCTION(clds_hash_table_remove_with_a_key_that_is_already_deleted_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
-    (void)clds_hash_table_delete(hash_table, hazard_pointers_thread, (void*)0x1, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
+    (void)clds_hash_table_delete(hash_table, test_context.hazard_pointers_thread, (void*)0x1, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -1972,21 +1949,20 @@ TEST_FUNCTION(clds_hash_table_remove_with_a_key_that_is_already_deleted_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_054: [ If a bucket is identified and the delete of the item from the underlying list fails, clds_hash_table_remove shall fail and return CLDS_HASH_TABLE_REMOVE_ERROR. ]*/
 TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_remove_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
@@ -1994,7 +1970,7 @@ TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_remove_
         .SetReturn(CLDS_SORTED_LIST_REMOVE_ERROR);
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2002,23 +1978,22 @@ TEST_FUNCTION(when_the_underlying_delete_from_list_fails_clds_hash_table_remove_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_055: [ If the element to be deleted is not found in the biggest array of buckets, then it shall be looked up in the next available array of buckets. ]*/
 TEST_FUNCTION(remove_looks_in_2_buckets)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2030,7 +2005,7 @@ TEST_FUNCTION(remove_looks_in_2_buckets)
     STRICT_EXPECTED_CALL(clds_sorted_list_remove_key(IGNORED_ARG, IGNORED_ARG, (void*)0x1, IGNORED_ARG, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2039,16 +2014,15 @@ TEST_FUNCTION(remove_looks_in_2_buckets)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, removed_item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_055: [ If the element to be deleted is not found in the biggest array of buckets, then it shall be looked up in the next available array of buckets. ]*/
 TEST_FUNCTION(remove_looks_in_3_buckets)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     // 1st bucket array has 1 bucket
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
@@ -2058,11 +2032,11 @@ TEST_FUNCTION(remove_looks_in_3_buckets)
     // 3rd bucket array has 4 buckets
     CLDS_HASH_TABLE_ITEM* item_4 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x4, item_4, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x4, item_4, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2075,7 +2049,7 @@ TEST_FUNCTION(remove_looks_in_3_buckets)
     STRICT_EXPECTED_CALL(clds_sorted_list_remove_key(IGNORED_ARG, IGNORED_ARG, (void*)0x1, IGNORED_ARG, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2084,23 +2058,22 @@ TEST_FUNCTION(remove_looks_in_3_buckets)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, removed_item);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_053: [ If the desired key is not found in the hash table (not found in any of the arrays of buckets), clds_hash_table_remove shall return CLDS_HASH_TABLE_REMOVE_NOT_FOUND. ]*/
 TEST_FUNCTION(when_item_is_not_found_in_any_bucket_remove_returns_NOT_FOUND)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2111,7 +2084,7 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_remove_returns_NOT_FOUND)
     STRICT_EXPECTED_CALL(clds_sorted_list_remove_key(IGNORED_ARG, IGNORED_ARG, (void*)0x3, IGNORED_ARG, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x3, &removed_item, NULL);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x3, &removed_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2119,26 +2092,25 @@ TEST_FUNCTION(when_item_is_not_found_in_any_bucket_remove_returns_NOT_FOUND)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_070: [ If the sequence_number argument is non-NULL, but no start sequence number was specified in clds_hash_table_create, clds_hash_table_remove shall fail and return CLDS_HASH_TABLE_REMOVE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_remove_with_non_NULL_sequence_no_and_NULL_start_sequence_no_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_REMOVE_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* removed_item;
     int64_t remove_seq_no;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_remove(hash_table, hazard_pointers_thread, (void*)0x1, &removed_item, &remove_seq_no);
+    result = clds_hash_table_remove(hash_table, test_context.hazard_pointers_thread, (void*)0x1, &removed_item, &remove_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2146,7 +2118,7 @@ TEST_FUNCTION(clds_hash_table_remove_with_non_NULL_sequence_no_and_NULL_start_se
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* clds_hash_table_find */
@@ -2158,13 +2130,12 @@ TEST_FUNCTION(clds_hash_table_remove_with_non_NULL_sequence_no_and_NULL_start_se
 TEST_FUNCTION(clds_hash_table_find_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 3, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 3, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2175,7 +2146,7 @@ TEST_FUNCTION(clds_hash_table_find_succeeds)
     STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, IGNORED_ARG, (void*)0x1));
 
     // act
-    result = clds_hash_table_find(hash_table, hazard_pointers_thread, (void*)0x1);
+    result = clds_hash_table_find(hash_table, test_context.hazard_pointers_thread, (void*)0x1);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2184,7 +2155,7 @@ TEST_FUNCTION(clds_hash_table_find_succeeds)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, result);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_034: [ clds_hash_table_find shall find the key identified by key in the hash table and on success return the item corresponding to it. ]*/
@@ -2192,17 +2163,16 @@ TEST_FUNCTION(clds_hash_table_find_succeeds)
 TEST_FUNCTION(clds_hash_table_find_2nd_item_out_of_3_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 3, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 3, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2213,7 +2183,7 @@ TEST_FUNCTION(clds_hash_table_find_2nd_item_out_of_3_succeeds)
     STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, IGNORED_ARG, (void*)0x2));
 
     // act
-    result = clds_hash_table_find(hash_table, hazard_pointers_thread, (void*)0x2);
+    result = clds_hash_table_find(hash_table, test_context.hazard_pointers_thread, (void*)0x2);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2222,7 +2192,7 @@ TEST_FUNCTION(clds_hash_table_find_2nd_item_out_of_3_succeeds)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, result);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_034: [ clds_hash_table_find shall find the key identified by key in the hash table and on success return the item corresponding to it. ]*/
@@ -2230,17 +2200,16 @@ TEST_FUNCTION(clds_hash_table_find_2nd_item_out_of_3_succeeds)
 TEST_FUNCTION(clds_hash_table_find_3rd_item_out_of_3_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 3, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 3, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2251,7 +2220,7 @@ TEST_FUNCTION(clds_hash_table_find_3rd_item_out_of_3_succeeds)
     STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, IGNORED_ARG, (void*)0x3));
 
     // act
-    result = clds_hash_table_find(hash_table, hazard_pointers_thread, (void*)0x3);
+    result = clds_hash_table_find(hash_table, test_context.hazard_pointers_thread, (void*)0x3);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2260,40 +2229,39 @@ TEST_FUNCTION(clds_hash_table_find_3rd_item_out_of_3_succeeds)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, result);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_035: [ If clds_hash_table is NULL, clds_hash_table_find shall fail and return NULL. ]*/
 TEST_FUNCTION(clds_hash_table_find_with_NULL_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* result;
-    umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_find(NULL, hazard_pointers_thread, (void*)0x3);
+    result = clds_hash_table_find(NULL, test_context.hazard_pointers_thread, (void*)0x3);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_IS_NULL(result);
 
     // cleanup
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_036: [ If clds_hazard_pointers_thread is NULL, clds_hash_table_find shall fail and return NULL. ]*/
 TEST_FUNCTION(clds_hash_table_find_with_NULL_clds_hazard_pointers_thread_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_HANDLE hash_table;
     CLDS_HASH_TABLE_ITEM* result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
@@ -2305,24 +2273,23 @@ TEST_FUNCTION(clds_hash_table_find_with_NULL_clds_hazard_pointers_thread_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_037: [ If key is NULL, clds_hash_table_find shall fail and return NULL. ]*/
 TEST_FUNCTION(clds_hash_table_find_with_NULL_key_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_find(hash_table, hazard_pointers_thread, NULL);
+    result = clds_hash_table_find(hash_table, test_context.hazard_pointers_thread, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2330,24 +2297,23 @@ TEST_FUNCTION(clds_hash_table_find_with_NULL_key_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_042: [ If the key is not found in the biggest array of buckets, the next bucket arrays shall be looked up. ]*/
 TEST_FUNCTION(clds_hash_table_find_looks_up_in_the_2nd_array_of_buckets)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2359,7 +2325,7 @@ TEST_FUNCTION(clds_hash_table_find_looks_up_in_the_2nd_array_of_buckets)
     STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, IGNORED_ARG, (void*)0x1));
 
     // act
-    result = clds_hash_table_find(hash_table, hazard_pointers_thread, (void*)0x1);
+    result = clds_hash_table_find(hash_table, test_context.hazard_pointers_thread, (void*)0x1);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2368,24 +2334,23 @@ TEST_FUNCTION(clds_hash_table_find_looks_up_in_the_2nd_array_of_buckets)
     // cleanup
     clds_hash_table_destroy(hash_table);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, result);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_043: [ If the key is not found at all, clds_hash_table_find shall return NULL. ]*/
 TEST_FUNCTION(when_key_is_not_found_in_any_bucket_levels_clds_hash_table_find_yields_NULL)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* result;
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_3, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_3, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2397,7 +2362,7 @@ TEST_FUNCTION(when_key_is_not_found_in_any_bucket_levels_clds_hash_table_find_yi
     STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, IGNORED_ARG, (void*)0x4));
 
     // act
-    result = clds_hash_table_find(hash_table, hazard_pointers_thread, (void*)0x4);
+    result = clds_hash_table_find(hash_table, test_context.hazard_pointers_thread, (void*)0x4);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2405,7 +2370,7 @@ TEST_FUNCTION(when_key_is_not_found_in_any_bucket_levels_clds_hash_table_find_yi
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* clds_hash_table_set_value */
@@ -2414,8 +2379,8 @@ TEST_FUNCTION(when_key_is_not_found_in_any_bucket_levels_clds_hash_table_find_yi
 TEST_FUNCTION(clds_hash_table_set_value_with_NULL_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* old_item;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
@@ -2423,15 +2388,15 @@ TEST_FUNCTION(clds_hash_table_set_value_with_NULL_hash_table_fails)
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_set_value(NULL, hazard_pointers_thread, (void*)0x4, item_1, NULL, NULL, &old_item, &set_value_seq_no);
+    result = clds_hash_table_set_value(NULL, test_context.hazard_pointers_thread, (void*)0x4, item_1, NULL, NULL, &old_item, &set_value_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SET_VALUE_RESULT, CLDS_HASH_TABLE_SET_VALUE_ERROR, result);
 
     // cleanup
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_1);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_080: [ If clds_hazard_pointers_thread is NULL, clds_hash_table_set_value shall fail and return CLDS_HASH_TABLE_SET_VALUE_ERROR. ]*/
@@ -2457,27 +2422,27 @@ TEST_FUNCTION(clds_hash_table_set_value_with_NULL_clds_hazard_pointers_thread_fa
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_1);
+    clds_hazard_pointers_destroy(hazard_pointers);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_081: [ If key is NULL, clds_hash_table_set_value shall fail and return CLDS_HASH_TABLE_SET_VALUE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_set_value_with_NULL_key_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* old_item;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     int64_t set_value_seq_no;
     volatile_atomic int64_t sequence_number;
     (void)interlocked_exchange_64(&sequence_number, 42);
-    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, &sequence_number, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, &sequence_number, NULL, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, NULL, item_1, NULL, NULL, &old_item, &set_value_seq_no);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, NULL, item_1, NULL, NULL, &old_item, &set_value_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2485,26 +2450,26 @@ TEST_FUNCTION(clds_hash_table_set_value_with_NULL_key_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_1);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_082: [ If new_item is NULL, clds_hash_table_set_value shall fail and return CLDS_HASH_TABLE_SET_VALUE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_set_value_with_NULL_new_item_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* old_item;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     int64_t set_value_seq_no;
     volatile_atomic int64_t sequence_number;
     (void)interlocked_exchange_64(&sequence_number, 42);
-    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, &sequence_number, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, &sequence_number, NULL, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x4, NULL, NULL, NULL, &old_item, &set_value_seq_no);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x4, NULL, NULL, NULL, &old_item, &set_value_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2512,25 +2477,25 @@ TEST_FUNCTION(clds_hash_table_set_value_with_NULL_new_item_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_083: [ If old_item is NULL, clds_hash_table_set_value shall fail and return CLDS_HASH_TABLE_SET_VALUE_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_set_value_with_NULL_old_item_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     int64_t set_value_seq_no;
     volatile_atomic int64_t sequence_number;
     (void)interlocked_exchange_64(&sequence_number, 42);
-    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, &sequence_number, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, &sequence_number, NULL, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x4, item_1, NULL, NULL, NULL, &set_value_seq_no);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x4, item_1, NULL, NULL, NULL, &set_value_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2538,7 +2503,7 @@ TEST_FUNCTION(clds_hash_table_set_value_with_NULL_old_item_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_1);
 }
 
@@ -2546,17 +2511,17 @@ TEST_FUNCTION(clds_hash_table_set_value_with_NULL_old_item_fails)
 TEST_FUNCTION(clds_hash_table_set_value_with_non_NULL_sequence_number_when_a_starting_sequence_number_was_not_specified)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* old_item;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     int64_t set_value_seq_no;
-    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
     umock_c_reset_all_calls();
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x4, item_1, NULL, NULL, &old_item, &set_value_seq_no);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x4, item_1, NULL, NULL, &old_item, &set_value_seq_no);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2564,8 +2529,8 @@ TEST_FUNCTION(clds_hash_table_set_value_with_non_NULL_sequence_number_when_a_sta
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_1);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_085: [ clds_hash_table_set_value shall go through all non top level bucket arrays and: ]*/
@@ -2577,24 +2542,23 @@ TEST_FUNCTION(clds_hash_table_set_value_with_non_NULL_sequence_number_when_a_sta
 TEST_FUNCTION(clds_hash_table_set_value_with_empty_hash_table_sets_the_value_on_the_top_level_buckets_array)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_set_value(IGNORED_ARG, IGNORED_ARG, (void*)0x1, (CLDS_SORTED_LIST_ITEM*)item, NULL, NULL, IGNORED_ARG, NULL, false))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL, NULL, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL, NULL, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2602,7 +2566,7 @@ TEST_FUNCTION(clds_hash_table_set_value_with_empty_hash_table_sets_the_value_on_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_085: [ clds_hash_table_set_value shall go through all non top level bucket arrays and: ]*/
@@ -2614,24 +2578,23 @@ TEST_FUNCTION(clds_hash_table_set_value_with_empty_hash_table_sets_the_value_on_
 TEST_FUNCTION(clds_hash_table_set_value_with_empty_hash_table_sets_the_value_on_the_top_level_buckets_array_with_condition_check)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_set_value(IGNORED_ARG, IGNORED_ARG, (void*)0x1, (CLDS_SORTED_LIST_ITEM*)item, test_item_condition_check, (void*)0x42, IGNORED_ARG, NULL, false))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item, test_item_condition_check, (void*)0x42, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, test_item_condition_check, (void*)0x42, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2639,7 +2602,7 @@ TEST_FUNCTION(clds_hash_table_set_value_with_empty_hash_table_sets_the_value_on_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 static void test_when_clds_sorted_list_set_value_fails_clds_hash_table_set_value_with_empty_hash_table_fails(
@@ -2647,25 +2610,24 @@ static void test_when_clds_sorted_list_set_value_fails_clds_hash_table_set_value
     CONDITION_CHECK_CB condition_check_cb, void* condition_check_context)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_set_value(IGNORED_ARG, IGNORED_ARG, (void*)0x1, (CLDS_SORTED_LIST_ITEM*)item, condition_check_cb, condition_check_context, IGNORED_ARG, NULL, false))
         .ValidateArgumentValue_clds_sorted_list(&linked_list)
         .SetReturn(sorted_list_result);
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item, condition_check_cb, condition_check_context, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, condition_check_cb, condition_check_context, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2673,8 +2635,8 @@ static void test_when_clds_sorted_list_set_value_fails_clds_hash_table_set_value
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_100: [ If clds_sorted_list_set_value returns any other value, clds_hash_table_set_value shall fail and return CLDS_HASH_TABLE_SET_VALUE_ERROR. ]*/
@@ -2699,19 +2661,18 @@ TEST_FUNCTION(when_clds_sorted_list_set_value_fails_with_CONDITION_NOT_MET_clds_
 TEST_FUNCTION(when_underlying_calls_fail_clds_hash_table_set_value_with_empty_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1))
         .CallCannotFail();
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list)
         .SetFailReturn(NULL);
     STRICT_EXPECTED_CALL(clds_sorted_list_set_value(IGNORED_ARG, IGNORED_ARG, (void*)0x1, (CLDS_SORTED_LIST_ITEM*)item, NULL, NULL, IGNORED_ARG, NULL, false))
@@ -2728,7 +2689,7 @@ TEST_FUNCTION(when_underlying_calls_fail_clds_hash_table_set_value_with_empty_ha
             umock_c_negative_tests_fail_call(i);
 
             // act
-            result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL, NULL, &old_item, NULL);
+            result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL, NULL, &old_item, NULL);
 
             // assert
             ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SET_VALUE_RESULT, CLDS_HASH_TABLE_SET_VALUE_ERROR, result, "On failed call %zu", i);
@@ -2737,23 +2698,22 @@ TEST_FUNCTION(when_underlying_calls_fail_clds_hash_table_set_value_with_empty_ha
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_107: [ If there is no sorted list in the bucket identified by the hash of the key, clds_hash_table_set_value shall advance to the next level of buckets. ]*/
 TEST_FUNCTION(when_there_is_no_sorted_list_in_lower_level_bucket_no_find_is_done_by_clds_hash_table_set_value)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
     CLDS_SORTED_LIST_HANDLE linked_list;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 4, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 4, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL));
     size_t i;
 
     CLDS_HASH_TABLE_ITEM* dummy_items[4];
@@ -2761,7 +2721,7 @@ TEST_FUNCTION(when_there_is_no_sorted_list_in_lower_level_bucket_no_find_is_done
     {
         dummy_items[i] = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
         ASSERT_IS_NOT_NULL(dummy_items[i]);
-        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)((4 * i) + 2), dummy_items[i], NULL));
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)((4 * i) + 2), dummy_items[i], NULL));
     }
 
     CLDS_HASH_TABLE_ITEM* new_item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
@@ -2771,13 +2731,13 @@ TEST_FUNCTION(when_there_is_no_sorted_list_in_lower_level_bucket_no_find_is_done
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
     STRICT_EXPECTED_CALL(clds_hazard_pointers_release(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x3));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_set_value(IGNORED_ARG, IGNORED_ARG, (void*)0x3, (CLDS_SORTED_LIST_ITEM*)new_item, NULL, NULL, IGNORED_ARG, NULL, false))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x3, new_item, NULL, NULL, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x3, new_item, NULL, NULL, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2785,7 +2745,7 @@ TEST_FUNCTION(when_there_is_no_sorted_list_in_lower_level_bucket_no_find_is_done
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_108: [ If there is a sorted list in the bucket identified by the hash of the key, clds_hash_table_set_value shall find the key in the list. ]*/
@@ -2793,32 +2753,31 @@ TEST_FUNCTION(when_there_is_no_sorted_list_in_lower_level_bucket_no_find_is_done
 TEST_FUNCTION(clds_hash_table_set_value_with_an_existing_item_in_the_lower_level_bucket_looks_for_the_item_in_the_lower_levels)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_SORTED_LIST_HANDLE linked_list;
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL));
     // add one filler item to expand the hash table
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_2, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_2, NULL));
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
     STRICT_EXPECTED_CALL(clds_hazard_pointers_release(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x2));
     STRICT_EXPECTED_CALL(clds_sorted_list_find_key(IGNORED_ARG, IGNORED_ARG, (void*)0x2));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, NULL, IGNORED_ARG, IGNORED_ARG))
         .CaptureReturn(&linked_list);
     STRICT_EXPECTED_CALL(clds_sorted_list_set_value(IGNORED_ARG, IGNORED_ARG, (void*)0x2, (CLDS_SORTED_LIST_ITEM*)item_3, NULL, NULL, IGNORED_ARG, NULL, false))
         .ValidateArgumentValue_clds_sorted_list(&linked_list);
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x2, item_3, NULL, NULL, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_3, NULL, NULL, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2826,7 +2785,7 @@ TEST_FUNCTION(clds_hash_table_set_value_with_an_existing_item_in_the_lower_level
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_110: [ If the key is found, clds_hash_table_set_value shall call clds_sorted_list_set_value with the key, new_item, condition_check_func, condition_check_context and old_item and only_if_exists set to true. ]*/
@@ -2834,18 +2793,17 @@ TEST_FUNCTION(clds_hash_table_set_value_with_an_existing_item_in_the_lower_level
 TEST_FUNCTION(clds_hash_table_set_value_with_an_existing_item_in_the_lower_level_finds_the_item_and_replaces_it_in_the_lower_levels)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL));
     // add one filler item to expand the hash table
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_2, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_2, NULL));
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2857,7 +2815,7 @@ TEST_FUNCTION(clds_hash_table_set_value_with_an_existing_item_in_the_lower_level
     STRICT_EXPECTED_CALL(clds_sorted_list_set_value(IGNORED_ARG, IGNORED_ARG, (void*)0x1, (CLDS_SORTED_LIST_ITEM*)item_3, NULL, NULL, IGNORED_ARG, NULL, true));
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item_3, NULL, NULL, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_3, NULL, NULL, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2865,8 +2823,8 @@ TEST_FUNCTION(clds_hash_table_set_value_with_an_existing_item_in_the_lower_level
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, old_item);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_110: [ If the key is found, clds_hash_table_set_value shall call clds_sorted_list_set_value with the key, new_item, condition_check_func, condition_check_context and old_item and only_if_exists set to true. ]*/
@@ -2874,18 +2832,17 @@ TEST_FUNCTION(clds_hash_table_set_value_with_an_existing_item_in_the_lower_level
 TEST_FUNCTION(clds_hash_table_set_value_with_condition_check_cb_has_cb_called)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL));
     // add one filler item to expand the hash table
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_2, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_2, NULL));
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2898,7 +2855,7 @@ TEST_FUNCTION(clds_hash_table_set_value_with_condition_check_cb_has_cb_called)
     STRICT_EXPECTED_CALL(test_item_condition_check((void*)0x42, IGNORED_ARG, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item_3, test_item_condition_check, (void*)0x42, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_3, test_item_condition_check, (void*)0x42, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2906,8 +2863,8 @@ TEST_FUNCTION(clds_hash_table_set_value_with_condition_check_cb_has_cb_called)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, old_item);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_110: [ If the key is found, clds_hash_table_set_value shall call clds_sorted_list_set_value with the key, new_item, condition_check_func, condition_check_context and old_item and only_if_exists set to true. ]*/
@@ -2915,18 +2872,17 @@ TEST_FUNCTION(clds_hash_table_set_value_with_condition_check_cb_has_cb_called)
 TEST_FUNCTION(clds_hash_table_set_value_fails_when_condition_check_returns_not_met)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL));
     // add one filler item to expand the hash table
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_2, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_2, NULL));
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2940,7 +2896,7 @@ TEST_FUNCTION(clds_hash_table_set_value_fails_when_condition_check_returns_not_m
     STRICT_EXPECTED_CALL(test_item_condition_check((void*)0x42, IGNORED_ARG, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item_3, test_item_condition_check, (void*)0x42, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_3, test_item_condition_check, (void*)0x42, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2949,7 +2905,7 @@ TEST_FUNCTION(clds_hash_table_set_value_fails_when_condition_check_returns_not_m
     // cleanup
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_3);
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_110: [ If the key is found, clds_hash_table_set_value shall call clds_sorted_list_set_value with the key, new_item, condition_check_func, condition_check_context and old_item and only_if_exists set to true. ]*/
@@ -2957,18 +2913,17 @@ TEST_FUNCTION(clds_hash_table_set_value_fails_when_condition_check_returns_not_m
 TEST_FUNCTION(clds_hash_table_set_value_fails_when_condition_check_returns_error)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL));
     // add one filler item to expand the hash table
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_2, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_2, NULL));
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -2982,7 +2937,7 @@ TEST_FUNCTION(clds_hash_table_set_value_fails_when_condition_check_returns_error
     STRICT_EXPECTED_CALL(test_item_condition_check((void*)0x42, IGNORED_ARG, IGNORED_ARG));
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item_3, test_item_condition_check, (void*)0x42, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_3, test_item_condition_check, (void*)0x42, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -2991,25 +2946,24 @@ TEST_FUNCTION(clds_hash_table_set_value_fails_when_condition_check_returns_error
     // cleanup
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_3);
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_111: [ If clds_sorted_list_set_value fails, clds_hash_table_set_value shall fail and return CLDS_HASH_TABLE_SET_VALUE_ERROR. ]*/
 TEST_FUNCTION(when_clds_sorted_list_set_value_in_lower_layer_fails_clds_hash_table_set_value_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_SET_VALUE_RESULT result;
     CLDS_HASH_TABLE_ITEM* old_item;
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, NULL, NULL, NULL);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, NULL, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     CLDS_HASH_TABLE_ITEM* item_3 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL));
     // add one filler item to expand the hash table
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x3, item_2, NULL));
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x3, item_2, NULL));
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(clds_hazard_pointers_acquire(IGNORED_ARG, IGNORED_ARG)).IgnoreAllCalls();
@@ -3022,7 +2976,7 @@ TEST_FUNCTION(when_clds_sorted_list_set_value_in_lower_layer_fails_clds_hash_tab
         .SetReturn(CLDS_SORTED_LIST_SET_VALUE_ERROR);
 
     // act
-    result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x1, item_3, NULL, NULL, &old_item, NULL);
+    result = clds_hash_table_set_value(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_3, NULL, NULL, &old_item, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3030,8 +2984,8 @@ TEST_FUNCTION(when_clds_sorted_list_set_value_in_lower_layer_fails_clds_hash_tab
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
     CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item_3);
+    destroy_test_context(&test_context);
 }
 
 /* on_sorted_list_skipped_seq_no */
@@ -3040,21 +2994,18 @@ TEST_FUNCTION(when_clds_sorted_list_set_value_in_lower_layer_fails_clds_hash_tab
 TEST_FUNCTION(on_sorted_list_skipped_seq_no_with_NULL_returns)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     SORTED_LIST_SKIPPED_SEQ_NO_CB test_on_sorted_list_skipped_seq_no;
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
         .CaptureArgumentValue_skipped_seq_no_cb(&test_on_sorted_list_skipped_seq_no);
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item, NULL));
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
@@ -3065,30 +3016,27 @@ TEST_FUNCTION(on_sorted_list_skipped_seq_no_with_NULL_returns)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_076: [ on_sorted_list_skipped_seq_no shall call the skipped sequence number callback passed to clds_hash_table_create and pass the skipped_sequence_no as skipped_sequence_no argument. ]*/
 TEST_FUNCTION(on_sorted_list_skipped_seq_no_calls_the_hash_table_skipped_seq_no)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     SORTED_LIST_SKIPPED_SEQ_NO_CB test_on_sorted_list_skipped_seq_no;
     void* test_on_sorted_list_skipped_seq_no_context;
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
         .CaptureArgumentValue_skipped_seq_no_cb(&test_on_sorted_list_skipped_seq_no)
         .CaptureArgumentValue_skipped_seq_no_cb_context(&test_on_sorted_list_skipped_seq_no_context);
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item, NULL));
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_skipped_seq_no_cb(NULL, 1));
@@ -3101,30 +3049,27 @@ TEST_FUNCTION(on_sorted_list_skipped_seq_no_calls_the_hash_table_skipped_seq_no)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_01_113: [ If the sequence number callback passed to clds_hash_table_create was NULL, on_sorted_list_skipped_seq_no shall return. ]*/
 TEST_FUNCTION(on_sorted_list_skipped_seq_no_with_NULL_hash_table_skipped_seq_no_returns)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, NULL, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
     SORTED_LIST_SKIPPED_SEQ_NO_CB test_on_sorted_list_skipped_seq_no;
     void* test_on_sorted_list_skipped_seq_no_context;
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(test_compute_hash((void*)0x1));
-    STRICT_EXPECTED_CALL(clds_sorted_list_create(hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_create(test_context.hazard_pointers, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG, IGNORED_ARG))
         .CaptureArgumentValue_skipped_seq_no_cb(&test_on_sorted_list_skipped_seq_no)
         .CaptureArgumentValue_skipped_seq_no_cb_context(&test_on_sorted_list_skipped_seq_no_context);
     STRICT_EXPECTED_CALL(clds_sorted_list_insert(IGNORED_ARG, IGNORED_ARG, (CLDS_SORTED_LIST_ITEM*)item, NULL));
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     // act
@@ -3135,7 +3080,7 @@ TEST_FUNCTION(on_sorted_list_skipped_seq_no_with_NULL_hash_table_skipped_seq_no_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* clds_hash_table_snapshot */
@@ -3144,33 +3089,31 @@ TEST_FUNCTION(on_sorted_list_skipped_seq_no_with_NULL_hash_table_skipped_seq_no_
 TEST_FUNCTION(clds_hash_table_snapshot_with_null_clds_hash_table_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    umock_c_reset_all_calls();
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
 
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(NULL, hazard_pointers_thread, &items, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(NULL, test_context.hazard_pointers_thread, &items, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
     ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_ERROR, result);
 
     // cleanup
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_014: [ If clds_hazard_pointers_thread is NULL then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_with_null_clds_hazard_pointers_thread_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
     umock_c_reset_all_calls();
 
     CLDS_HASH_TABLE_ITEM** items;
@@ -3185,25 +3128,22 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_null_clds_hazard_pointers_thread_fai
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_015: [ If items is NULL then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_with_null_items_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
     umock_c_reset_all_calls();
 
     uint64_t item_count;
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, NULL, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, NULL, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3211,25 +3151,22 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_null_items_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_016: [ If item_count is NULL then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_with_null_item_count_fails)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
     umock_c_reset_all_calls();
 
     CLDS_HASH_TABLE_ITEM** items;
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, NULL);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, NULL);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3237,7 +3174,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_null_item_count_fails)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
@@ -3247,19 +3184,16 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_null_item_count_fails)
 TEST_FUNCTION(clds_hash_table_snapshot_with_empty_table_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
     umock_c_reset_all_calls();
 
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3270,7 +3204,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_empty_table_succeeds)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
@@ -3287,31 +3221,28 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_empty_table_succeeds)
 TEST_FUNCTION(clds_hash_table_snapshot_with_1_item_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item, NULL);
     umock_c_reset_all_calls();
 
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
     STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
 
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3330,7 +3261,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_1_item_succeeds)
     free(items);
 
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
@@ -3347,12 +3278,9 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_1_item_succeeds)
 TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 20, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 20, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* original_items[10];
     bool found_originals[10];
@@ -3361,7 +3289,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_succeeds)
     for (uint32_t i = 0; i < number_of_items; i++)
     {
         original_items[i] = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)(uintptr_t)(0x4242 + i));
-        (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)(uintptr_t)((20 * i) + 1), original_items[i], NULL);
+        (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)(uintptr_t)((20 * i) + 1), original_items[i], NULL);
         found_originals[i] = false;
     }
     umock_c_reset_all_calls();
@@ -3370,16 +3298,16 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_succeeds)
     uint64_t item_count;
 
     STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
 
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3420,7 +3348,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_succeeds)
     free(items);
 
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
@@ -3437,12 +3365,9 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_succeeds)
 TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* original_items[10];
     bool found_originals[10];
@@ -3453,7 +3378,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_succeeds)
     for (uint32_t i = 0; i < number_of_items; i++)
     {
         original_items[i] = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)(uintptr_t)(0x4242 + i));
-        (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
+        (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
         found_originals[i] = false;
     }
     umock_c_reset_all_calls();
@@ -3464,20 +3389,20 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_succeeds)
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
         STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
     }
 
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
     }
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3518,7 +3443,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_succeeds)
     free(items);
 
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
@@ -3535,12 +3460,9 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_succeeds)
 TEST_FUNCTION(clds_hash_table_snapshot_with_100_items_multiple_buckets_different_hashes_succeeds)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* original_items[100];
     bool found_originals[100];
@@ -3554,7 +3476,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_100_items_multiple_buckets_different
 
         STRICT_EXPECTED_CALL(test_compute_hash((void*)(uintptr_t)(0x1 + i)))
             .SetReturn(i);
-        (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
+        (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
         found_originals[i] = false;
         umock_c_reset_all_calls();
     }
@@ -3566,20 +3488,20 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_100_items_multiple_buckets_different
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
         STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
     }
 
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
     }
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3620,26 +3542,23 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_100_items_multiple_buckets_different
     free(items);
 
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_fails_when_underlying_functions_fail)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 20, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 20, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* original_items[10];
 
     for (uint32_t i = 0; i < 10; i++)
     {
         original_items[i] = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)(uintptr_t)(0x4242 + i));
-        (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)(uintptr_t)(0x1 + (20 * i)), original_items[i], NULL);
+        (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)(uintptr_t)(0x1 + (20 * i)), original_items[i], NULL);
     }
     umock_c_reset_all_calls();
 
@@ -3647,12 +3566,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_fails_when_unde
     uint64_t item_count;
 
     STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
 
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
 
     umock_c_negative_tests_snapshot();
@@ -3665,7 +3584,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_fails_when_unde
             umock_c_negative_tests_fail_call(i);
 
             // act
-            CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+            CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
             // assert
             ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_ERROR, result, "On failed call %zu", i);
@@ -3674,19 +3593,17 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_fails_when_unde
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_fails_when_underlying_functions_fail)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
     CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* original_items[10];
 
@@ -3695,7 +3612,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_fails_when
     for (uint32_t i = 0; i < 10; i++)
     {
         original_items[i] = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)(uintptr_t)(0x4242 + i));
-        (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
+        (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
     }
     umock_c_reset_all_calls();
 
@@ -3705,15 +3622,15 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_fails_when
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
         STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
     }
 
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
     }
 
@@ -3727,7 +3644,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_fails_when
             umock_c_negative_tests_fail_call(i);
 
             // act
-            CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+            CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
             // assert
             ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_ERROR, result, "On failed call %zu", i);
@@ -3736,19 +3653,16 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_fails_when
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_hashes_fails_when_underlying_functions_fail)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 2, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* original_items[20];
     uint32_t number_of_items = 20;
@@ -3761,7 +3675,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_
 
         STRICT_EXPECTED_CALL(test_compute_hash((void*)(uintptr_t)(0x1 + i)))
             .SetReturn(i);
-        (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
+        (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)(uintptr_t)(0x1 + i), original_items[i], NULL);
         umock_c_reset_all_calls();
     }
     umock_c_reset_all_calls();
@@ -3772,15 +3686,15 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
         STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
     }
 
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
+        STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
     }
 
@@ -3794,7 +3708,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_
             umock_c_negative_tests_fail_call(i);
 
             // act
-            CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+            CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
             // assert
             ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_ERROR, result, "On failed call %zu", i);
@@ -3803,25 +3717,22 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 /* Tests_SRS_CLDS_HASH_TABLE_42_022: [ If the addition of the list count causes overflow then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_fails_if_number_of_items_would_overflow)
 {
     // arrange
-    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
-    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
-    CLDS_HASH_TABLE_HANDLE hash_table;
-    volatile_atomic int64_t start_seq_no;
-    (void)interlocked_exchange_64(&start_seq_no, 0);
-    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, hazard_pointers, &start_seq_no, test_skipped_seq_no_cb, NULL);
+    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
+    setup_test_context(&test_context);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
 
     CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x1, item_1, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
 
     CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4243);
-    (void)clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)0x2, item_2, NULL);
+    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
 
     umock_c_reset_all_calls();
 
@@ -3832,18 +3743,18 @@ TEST_FUNCTION(clds_hash_table_snapshot_fails_if_number_of_items_would_overflow)
     uint64_t mocked_item_count_2 = UINT64_MAX / 2 + 1;
 
     STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG))
         .CopyOutArgumentBuffer_item_count(&mocked_item_count_1, sizeof(mocked_item_count_1));
 
     STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, hazard_pointers_thread, IGNORED_ARG))
+    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG))
         .CopyOutArgumentBuffer_item_count(&mocked_item_count_2, sizeof(mocked_item_count_2));
 
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
 
     // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
 
     // assert
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
@@ -3851,7 +3762,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_fails_if_number_of_items_would_overflow)
 
     // cleanup
     clds_hash_table_destroy(hash_table);
-    clds_hazard_pointers_destroy(hazard_pointers);
+    destroy_test_context(&test_context);
 }
 
 END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)


### PR DESCRIPTION
Add a NULL check in the skipped_seq_no_cb in order to not crash in the setup that we have in the perf test.