### PR TITLE
Add TQUEUE tests and code

### DIFF
--- a/devdoc/tqueue_requirements.md
+++ b/devdoc/tqueue_requirements.md
@@ -18,11 +18,8 @@ The module provides the following functionality:
 
 The module allows the user to specify 3 different callback functions:
 
-- A push callback (which is invoked by the queue as a result of a push call, allowing the user to fill in the information in T rather than performing a memory copy).
-A typical use for a queue of a `THANDLE` would be to have a `THANDLE_INITIALIZE` call performed in the push function callback.
-
-- A pop callback (which is invoked by the queue as a result of a pop call, allowing the user to extract any information from T rather than performing a memory copy).
-A typical use for a queue of a `THANDLE` would be to have a `THANDLE_MOVE` or `THANDLE_INITIALIZE_MOVE` call performed in the push function callback.
+- A copy item callback (which is invoked by the queue as a result of a push call or a pop call, allowing the user to fill in the information in/from T rather than performing a memory copy).
+A typical use for a queue of a `THANDLE` would be to have a `THANDLE_ASSIGN` from the source to the destination parameters.
 
 - A dispose item function (which is invoked by the queue when the queue is disposed and there are still items in the queue).
 A typical use for a queue of a `THANDLE` would be to have a `THANDLE_ASSIGN` with `NULL` performed in the dispose function callback.
@@ -31,7 +28,7 @@ A typical use for a queue of a `THANDLE` would be to have a `THANDLE_ASSIGN` wit
 
 If no push/pop/dispose callbacks functions are specified by the user, the queue copies the memory of T passed to `TQUEUE_PUSH`, respectively `TQUEUE_POP`.
 
-The callbacks used for push/pop/dispose/pop condition check item are not re-entrant, they should not call `TQUEUE` APIs on the same queue.
+The callbacks used for copy item/dispose item/pop condition are not re-entrant, they should not call `TQUEUE` APIs on the same queue.
 
 Because `TQUEUE` is a kind of `THANDLE`, all of `THANDLE`'s APIs apply to `TQUEUE`. For convenience the following macros are provided out of the box with the same semantics as those of `THANDLE`'s:
 
@@ -93,37 +90,27 @@ MU_DEFINE_ENUM(TQUEUE_POP_RESULT, TQUEUE_POP_RESULT_VALUES);
 The macros expand to these useful somewhat more useful APIs:
 
 ```c
-TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(T) push_cb_function, TQUEUE_POP_CB_FUNC(T) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_item_function_context);
-int TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* push_function_context)
-TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* pop_function_context, TQUEUE_DEFINE_CONDITION_FUNCTION_TYPE_NAME(T), condition_function, void*, condition_function_context);
+TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_COPY_ITEM_FUNC(T) copy_item_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_item_function_context);
+int TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* copy_function_context)
+TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* copy_function_context, TQUEUE_DEFINE_CONDITION_FUNCTION_TYPE_NAME(T), condition_function, void*, condition_function_context);
 ```
 
-The signature of the push callback function `TQUEUE_PUSH_CB_FUNC(T)` is:
+The signature of the push callback function `TQUEUE_COPY_ITEM_FUNC(T)` is:
 
 ```c
-void TQUEUE_DEFINE_PUSH_CB_FUNCTION_TYPE_NAME(T)(void* context, T* push_dst, T* push_src);
+void TQUEUE_DEFINE_COPY_ITEM_FUNCTION_TYPE_NAME(T)(void* context, T* push_dst, T* push_src);
 ```
 
-Note that `push_dst` is the pointer in the queue memory, `push_src` is the pointer to the user owned `T` being pushed in the queue.
-
-The signature of the pop callback function `TQUEUE_POP_CB_FUNC(T)` is:
-
-```c
-void TQUEUE_DEFINE_POP_CB_FUNCTION_TYPE_NAME(T)(void* context, T* pop_dst, T* pop_src);
-```
-
-Note that `pop_dst` is the user T pointer which receives the popped item, `pop_src` is the pointer to the queue memory.
-
-The signature of the dispose function `TQUEUE_DISPOSE_FUNC(T)` is:
+The signature of the dispose function `TQUEUE_DISPOSE_ITEM_FUNC(T)` is:
 
 ```c
 void TQUEUE_DEFINE_DISPOSE_FUNCTION_TYPE_NAME(T)(void* context, T* item);
 ```
 
-The signature of the dispose function `TQUEUE_CONDITION_FUNC(T)` is:
+The signature of the condition function `TQUEUE_CONDITION_FUNC(T)` is:
 
 ```c
-bool TQUEUE_DEFINE_DISPOSE_FUNCTION_TYPE_NAME(T)(void* context, T* item);
+bool TQUEUE_DEFINE_CONDITION_FUNCTION_TYPE_NAME(T)(void* context, T* item);
 ```
 
 It returns `true` if the condition is satisfied and the pop should be performed, `false` otherwise.
@@ -171,14 +158,14 @@ TQUEUE_TYPE_DEFINE(int32_t);
 
 ### TQUEUE_CREATE(T)
 ```c
-TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(T) push_cb_function, TQUEUE_POP_CB_FUNC(T) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_item_function_context);
+TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_COPY_ITEM_FUNC(T) copy_item_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_item_function_context);
 ```
 
 `TQUEUE_CREATE(T)` creates a new `TQUEUE(T)`.
 
 **SRS_TQUEUE_01_001: [** If `queue_size` is 0, `TQUEUE_CREATE(T)` shall fail and return `NULL`. **]**
 
-**SRS_TQUEUE_01_002: [** If any of `push_cb_function`, `pop_cb_function` and `dispose_item_function` is `NULL` and at least one of them is not `NULL`, `TQUEUE_CREATE(T)` shall fail and return `NULL`. **]**
+**SRS_TQUEUE_01_002: [** If any of `copy_item_function` and `dispose_item_function` is `NULL` and at least one of them is not `NULL`, `TQUEUE_CREATE(T)` shall fail and return `NULL`. **]**
 
 **SRS_TQUEUE_01_003: [** `TQUEUE_CREATE(T)` shall call `THANDLE_MALLOC_FLEX` with `TQUEUE_DISPOSE_FUNC(T)` as dispose function, `nmemb` set to `queue_size` and `size` set to `sizeof(T)`. **]**
 
@@ -207,7 +194,7 @@ void TQUEUE_DISPOSE_FUNC(T)(TQUEUE(T) tqueue);
 
 ### TQUEUE_PUSH(T)
 ```c
-TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* push_cb_function_context)
+TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* copy_item_function_context)
 ```
 
 `TQUEUE_PUSH(T)` pushes an item in the queue.
@@ -232,9 +219,9 @@ TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* push_cb_funct
 
   - **SRS_TQUEUE_01_023: [** If the state of the array entry corresponding to the head is not `NOT_USED`, `TQUEUE_PUSH(T)` shall try changing the state again. **]**
 
-- **SRS_TQUEUE_01_019: [** If no `push_cb_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall copy the value of `item` into the array entry value whose state was changed to `PUSHING`. **]**
+- **SRS_TQUEUE_01_019: [** If no `copy_item_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall copy the value of `item` into the array entry value whose state was changed to `PUSHING`. **]**
 
-- **SRS_TQUEUE_01_024: [** If a `push_cb_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall call the `push_cb_function` with `push_cb_function_context` as `context`, a pointer to the array entry value whose state was changed to `PUSHING` as `push_dst` and `item` as `push_src`. **]**
+- **SRS_TQUEUE_01_024: [** If a `copy_item_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall call the `copy_item_function` with `copy_item_function_context` as `context`, a pointer to the array entry value whose state was changed to `PUSHING` as `push_dst` and `item` as `push_src`. **]**
 
 - **SRS_TQUEUE_01_020: [** `TQUEUE_PUSH(T)` shall set the state to `USED` by using `interlocked_exchange`. **]**
 
@@ -275,12 +262,14 @@ TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* pop_function_co
 
     - **SRS_TQUEUE_01_044: [** If incrementing the tail by using `interlocked_compare_exchange_64` does not succeed, `TQUEUE_POP(T)` shall revert the state of the array entry to `USED` and retry. **]**
 
-  - **SRS_TQUEUE_01_032: [** If a `pop_cb_function` was not specified in `TQUEUE_CREATE(T)`: **]**
+  - **SRS_TQUEUE_01_032: [** If a `copy_item_function` was not specified in `TQUEUE_CREATE(T)`: **]**
   
     - **SRS_TQUEUE_01_033: [** `TQUEUE_POP(T)` shall copy array entry value whose state was changed to `POPPING` to `item`. **]**
 
-  - **SRS_TQUEUE_01_037: [** If a `pop_cb_function` was specified in `TQUEUE_CREATE(T)`: **]**
+  - **SRS_TQUEUE_01_037: [** If `copy_item_function` and `sispose_item_function` were specified in `TQUEUE_CREATE(T)`: **]**
   
-    - **SRS_TQUEUE_01_038: [** `TQUEUE_POP(T)` shall call `pop_cb_function` with `pop_cb_function_context` as `context`, the array entry value whose state was changed to `POPPING` to `item` as `pop_src` and `item` as `pop_dst`. **]**
+    - **SRS_TQUEUE_01_038: [** `TQUEUE_POP(T)` shall call `copy_item_function` with `copy_item_function_context` as `context`, the array entry value whose state was changed to `POPPING` to `item` as `pop_src` and `item` as `pop_dst`. **]**
+
+    - **SRS_TQUEUE_01_045: [** `TQUEUE_POP(T)` shall call `dispose_item_function` with `dispose_item_function_context` as `context` and the array entry value whose state was changed to `POPPING` as `item`. **]**
 
   - **SRS_TQUEUE_01_034: [** `TQUEUE_POP(T)` shall set the state to `NOT_USED` by using `interlocked_exchange`, succeed and return `TQUEUE_POP_OK`. **]**

--- a/devdoc/tqueue_requirements.md
+++ b/devdoc/tqueue_requirements.md
@@ -19,7 +19,7 @@ The module provides the following functionality:
 The module allows the user to specify 3 different callback functions:
 
 - A copy item callback (which is invoked by the queue as a result of a push call or a pop call, allowing the user to fill in the information in/from T rather than performing a memory copy).
-A typical use for a queue of a `THANDLE` would be to have a `THANDLE_ASSIGN` from the source to the destination parameters.
+A typical use for a queue of a `THANDLE` would be to have a `THANDLE_INITIALIZE`, initializing the `dst` with the `src`.
 
 - A dispose item function (which is invoked by the queue when the queue is disposed and there are still items in the queue).
 A typical use for a queue of a `THANDLE` would be to have a `THANDLE_ASSIGN` with `NULL` performed in the dispose function callback.

--- a/devdoc/tqueue_requirements.md
+++ b/devdoc/tqueue_requirements.md
@@ -211,13 +211,13 @@ TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* copy_item_fun
 
 - **SRS_TQUEUE_01_022: [** If the queue is full (current head >= current tail + queue size), `TQUEUE_PUSH(T)` shall return `TQUEUE_PUSH_QUEUE_FULL`. **]**
 
-- **SRS_TQUEUE_01_018: [** Using `interlocked_compare_exchange_64`, `TQUEUE_PUSH(T)` shall replace the head value with the head value obtained earlier + 1. **]**
-
-- **SRS_TQUEUE_01_043: [** If the queue head has changed, `TQUEUE_PUSH(T)` shall try again. **]**
-
 - **SRS_TQUEUE_01_017: [** Using `interlocked_compare_exchange`, `TQUEUE_PUSH(T)` shall change the head array entry state to `PUSHING` (from `NOT_USED`). **]**
 
-  - **SRS_TQUEUE_01_023: [** If the state of the array entry corresponding to the head is not `NOT_USED`, `TQUEUE_PUSH(T)` shall try changing the state again. **]**
+  - **SRS_TQUEUE_01_023: [** If the state of the array entry corresponding to the head is not `NOT_USED`, `TQUEUE_PUSH(T)` shall retry the whole push. **]**
+
+- **SRS_TQUEUE_01_018: [** Using `interlocked_compare_exchange_64`, `TQUEUE_PUSH(T)` shall replace the head value with the head value obtained earlier + 1. **]**
+
+- **SRS_TQUEUE_01_043: [** If the queue head has changed, `TQUEUE_PUSH(T)` shall set the state back to `NOT_USED` and retry the push. **]**
 
 - **SRS_TQUEUE_01_019: [** If no `copy_item_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall copy the value of `item` into the array entry value whose state was changed to `PUSHING`. **]**
 

--- a/devdoc/tqueue_requirements.md
+++ b/devdoc/tqueue_requirements.md
@@ -197,7 +197,7 @@ void TQUEUE_DISPOSE_FUNC(T)(TQUEUE(T) tqueue);
 TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* copy_item_function_context)
 ```
 
-`TQUEUE_PUSH(T)` pushes an item in the queue.
+`TQUEUE_PUSH(T)` pushes an item in the queue at the head.
 
 **SRS_TQUEUE_01_012: [** If `tqueue` is `NULL` then `TQUEUE_PUSH(T)` shall fail and return `TQUEUE_PUSH_INVALID_ARG`. **]**
 
@@ -232,7 +232,7 @@ TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* copy_item_fun
 TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* pop_function_context, TQUEUE_CONDITION_FUNC(T), condition_function, void*, condition_function_context);
 ```
 
-`TQUEUE_POP(T)` pops an item from the queue if available.
+`TQUEUE_POP(T)` pops an item from the queue (from the tail) if available.
 
 **SRS_TQUEUE_01_025: [** If `tqueue` is `NULL` then `TQUEUE_POP(T)` shall fail and return `TQUEUE_POP_INVALID_ARG`. **]**
 
@@ -244,7 +244,7 @@ TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* pop_function_co
 
 - **SRS_TQUEUE_01_029: [** `TQUEUE_POP(T)` shall obtain the current tail queue by calling `interlocked_add_64`. **]**
 
-- **SRS_TQUEUE_01_035: [** If the queue is empty (current tail == current head), `TQUEUE_POP(T)` shall return `TQUEUE_POP_QUEUE_EMPTY`. **]**
+- **SRS_TQUEUE_01_035: [** If the queue is empty (current tail >= current head), `TQUEUE_POP(T)` shall return `TQUEUE_POP_QUEUE_EMPTY`. **]**
 
 - **SRS_TQUEUE_01_030: [** Using `interlocked_compare_exchange`, `TQUEUE_PUSH(T)` shall set the tail array entry state to `POPPING` (from `USED`). **]**
 

--- a/devdoc/tqueue_requirements.md
+++ b/devdoc/tqueue_requirements.md
@@ -27,11 +27,11 @@ A typical use for a queue of a `THANDLE` would be to have a `THANDLE_MOVE` or `T
 - A dispose item function (which is invoked by the queue when the queue is disposed and there are still items in the queue).
 A typical use for a queue of a `THANDLE` would be to have a `THANDLE_ASSIGN` with `NULL` performed in the dispose function callback.
 
+- A condition function used for allowing the pop of an item. If the called condition function returns `true`, the pop is performed. If it returns `false`, the pop is not performed.
+
 If no push/pop/dispose callbacks functions are specified by the user, the queue copies the memory of T passed to `TQUEUE_PUSH`, respectively `TQUEUE_POP`.
 
-The callbacks used for push/pop/dispose item are not re-entrant, they should not call `TQUEUE` APIs on the same queue.
-
-When using a pop callback function the queue also allows the user to reject a pop (thus effectively implementing a conditional pop).
+The callbacks used for push/pop/dispose/pop condition check item are not re-entrant, they should not call `TQUEUE` APIs on the same queue.
 
 Because `TQUEUE` is a kind of `THANDLE`, all of `THANDLE`'s APIs apply to `TQUEUE`. For convenience the following macros are provided out of the box with the same semantics as those of `THANDLE`'s:
 
@@ -80,12 +80,6 @@ MU_DEFINE_ENUM(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_RESULT_VALUES);
 
 MU_DEFINE_ENUM(TQUEUE_POP_RESULT, TQUEUE_POP_RESULT_VALUES);
 
-#define TQUEUE_POP_CB_FUNCTION_RESULT_VALUES \
-    TQUEUE_POP_CB_FUNCTION_OK, \
-    TQUEUE_POP_CB_FUNCTION_POP_REJECTED
-
-MU_DEFINE_ENUM(TQUEUE_POP_CB_FUNCTION_RESULT, TQUEUE_POP_CB_FUNCTION_RESULT_VALUES);
-
 /*to be used as the type of handle*/
 #define TQUEUE(T)
 
@@ -99,15 +93,15 @@ MU_DEFINE_ENUM(TQUEUE_POP_CB_FUNCTION_RESULT, TQUEUE_POP_CB_FUNCTION_RESULT_VALU
 The macros expand to these useful somewhat more useful APIs:
 
 ```c
-TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(T) push_function, TQUEUE_POP_CB_FUNC(T) pop_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_function_context);
-int TQUEUE_PUSH(T)(TQUEUE(T) tqueue, const T item, void* push_function_context)
+TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(T) push_cb_function, TQUEUE_POP_CB_FUNC(T) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_item_function_context);
+int TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* push_function_context)
 TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* pop_function_context, TQUEUE_DEFINE_CONDITION_FUNCTION_TYPE_NAME(T), condition_function, void*, condition_function_context);
 ```
 
 The signature of the push callback function `TQUEUE_PUSH_CB_FUNC(T)` is:
 
 ```c
-void TQUEUE_DEFINE_PUSH_CB_FUNCTION_TYPE_NAME(T)(void* context, T* push_dst, const T* push_src);
+void TQUEUE_DEFINE_PUSH_CB_FUNCTION_TYPE_NAME(T)(void* context, T* push_dst, T* push_src);
 ```
 
 Note that `push_dst` is the pointer in the queue memory, `push_src` is the pointer to the user owned `T` being pushed in the queue.
@@ -115,7 +109,7 @@ Note that `push_dst` is the pointer in the queue memory, `push_src` is the point
 The signature of the pop callback function `TQUEUE_POP_CB_FUNC(T)` is:
 
 ```c
-TQUEUE_POP_CB_FUNCTION_RESULT TQUEUE_DEFINE_POP_CB_FUNCTION_TYPE_NAME(T)(void* context, T* pop_dst, const T* pop_src);
+void TQUEUE_DEFINE_POP_CB_FUNCTION_TYPE_NAME(T)(void* context, T* pop_dst, T* pop_src);
 ```
 
 Note that `pop_dst` is the user T pointer which receives the popped item, `pop_src` is the pointer to the queue memory.
@@ -123,8 +117,16 @@ Note that `pop_dst` is the user T pointer which receives the popped item, `pop_s
 The signature of the dispose function `TQUEUE_DISPOSE_FUNC(T)` is:
 
 ```c
-void TQUEUE_DEFINE_DISPOSE_FUNCTION_TYPE_NAME(T)(void* context, const T* item);
+void TQUEUE_DEFINE_DISPOSE_FUNCTION_TYPE_NAME(T)(void* context, T* item);
 ```
+
+The signature of the dispose function `TQUEUE_CONDITION_FUNC(T)` is:
+
+```c
+bool TQUEUE_DEFINE_DISPOSE_FUNCTION_TYPE_NAME(T)(void* context, T* item);
+```
+
+It returns `true` if the condition is satisfied and the pop should be performed, `false` otherwise.
 
 ### TQUEUE(T)
 
@@ -169,24 +171,24 @@ TQUEUE_TYPE_DEFINE(int32_t);
 
 ### TQUEUE_CREATE(T)
 ```c
-TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(T) push_cb_function, TQUEUE_POP_CB_FUNC(T) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_function_context);
+TQUEUE(T) TQUEUE_CREATE(T)(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(T) push_cb_function, TQUEUE_POP_CB_FUNC(T) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_item_function_context);
 ```
 
 `TQUEUE_CREATE(T)` creates a new `TQUEUE(T)`.
 
-If `queue_size` is 0, `TQUEUE_CREATE(T)` shall fail and return `NULL`.
+**SRS_TQUEUE_01_001: [** If `queue_size` is 0, `TQUEUE_CREATE(T)` shall fail and return `NULL`. **]**
 
-If any of `push_cb_function`, `pop_cb_function` and `dispose_item_function` is `NULL` and at least one of them is not `NULL`, `TQUEUE_CREATE(T)` shall fail and return `NULL`.
+**SRS_TQUEUE_01_002: [** If any of `push_cb_function`, `pop_cb_function` and `dispose_item_function` is `NULL` and at least one of them is not `NULL`, `TQUEUE_CREATE(T)` shall fail and return `NULL`. **]**
 
-`TQUEUE_CREATE(T)` shall call `THANDLE_MALLOC_FLEX` with `TQUEUE_DISPOSE_FUNC(T)` as dispose function, `nmemb` set to `queue_size` and `size` set to `sizeof(T)`.
+**SRS_TQUEUE_01_003: [** `TQUEUE_CREATE(T)` shall call `THANDLE_MALLOC_FLEX` with `TQUEUE_DISPOSE_FUNC(T)` as dispose function, `nmemb` set to `queue_size` and `size` set to `sizeof(T)`. **]**
 
-`TQUEUE_CREATE(T)` shall initialize the head and tail of the list with 0 by using `interlocked_exchange_64`.
+**SRS_TQUEUE_01_004: [** `TQUEUE_CREATE(T)` shall initialize the head and tail of the list with 0 by using `interlocked_exchange_64`. **]**
 
-`TQUEUE_CREATE(T)` shall initialize the state for each entry in the array used for the queue with `NOT_USED` by using `interlocked_exchange`.
+**SRS_TQUEUE_01_005: [** `TQUEUE_CREATE(T)` shall initialize the state for each entry in the array used for the queue with `NOT_USED` by using `interlocked_exchange`. **]**
 
-`TQUEUE_CREATE(T)` shall succeed and return a non-`NULL` value.
+**SRS_TQUEUE_01_006: [** `TQUEUE_CREATE(T)` shall succeed and return a non-`NULL` value. **]**
 
-If there are any failures then `TQUEUE_CREATE(T)` shall fail and return `NULL`.
+**SRS_TQUEUE_01_007: [** If there are any failures then `TQUEUE_CREATE(T)` shall fail and return `NULL`. **]**
 
 ### TQUEUE_DISPOSE_FUNC(T)
 ```c
@@ -195,86 +197,90 @@ void TQUEUE_DISPOSE_FUNC(T)(TQUEUE(T) tqueue);
 
 `TQUEUE_DISPOSE_FUNC(T)` is called when there are no more references to the queue and the contents of it should be disposed of.
 
-If `dispose_item_function` passed to `TQUEUE_CREATE(T)` is `NULL`, `TQUEUE_DISPOSE_FUNC(T)` shall return.
+**SRS_TQUEUE_01_008: [** If `dispose_item_function` passed to `TQUEUE_CREATE(T)` is `NULL`, `TQUEUE_DISPOSE_FUNC(T)` shall return. **]**
 
-Otherwise, `TQUEUE_DISPOSE_FUNC(T)` shall obtain the current head queue by calling `interlocked_add_64`.
+**SRS_TQUEUE_01_009: [** Otherwise, `TQUEUE_DISPOSE_FUNC(T)` shall obtain the current queue head by calling `interlocked_add_64`. **]**
 
-`TQUEUE_DISPOSE_FUNC(T)` shall obtain the current tail queue by calling `interlocked_add_64`.
+**SRS_TQUEUE_01_010: [** `TQUEUE_DISPOSE_FUNC(T)` shall obtain the current queue tail by calling `interlocked_add_64`. **]**
 
-For each item in the queue, `dispose_item_function` shall be called with `dispose_function_context` and a pointer to the array entry value (T*).
+**SRS_TQUEUE_01_011: [** For each item in the queue, `dispose_item_function` shall be called with `dispose_item_function_context` and a pointer to the array entry value (T*). **]**
 
 ### TQUEUE_PUSH(T)
 ```c
-TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, const T item, void* push_cb_function_context)
+TQUEUE_PUSH_RESULT TQUEUE_PUSH(T)(TQUEUE(T) tqueue, T* item, void* push_cb_function_context)
 ```
 
 `TQUEUE_PUSH(T)` pushes an item in the queue.
 
-If `tqueue` is `NULL` then `TQUEUE_PUSH(T)` shall fail and return `TQUEUE_PUSH_INVALID_ARG`.
+**SRS_TQUEUE_01_012: [** If `tqueue` is `NULL` then `TQUEUE_PUSH(T)` shall fail and return `TQUEUE_PUSH_INVALID_ARG`. **]**
 
-`TQUEUE_PUSH(T)` shall execute the following actions until it is either able to push the item in the queue or it fails:
+**SRS_TQUEUE_01_013: [** If `item` is `NULL` then `TQUEUE_PUSH(T)` shall fail and return `TQUEUE_PUSH_INVALID_ARG`. **]**
 
-- `TQUEUE_PUSH(T)` shall obtain the current head queue by calling `interlocked_add_64`.
+**SRS_TQUEUE_01_014: [** `TQUEUE_PUSH(T)` shall execute the following actions until it is either able to push the item in the queue or the queue is full: **]**
 
-- `TQUEUE_PUSH(T)` shall obtain the current tail queue by calling `interlocked_add_64`.
+- **SRS_TQUEUE_01_015: [** `TQUEUE_PUSH(T)` shall obtain the current head queue by calling `interlocked_add_64`. **]**
 
-- If the queue is full (current head >= current tail + queue size), `TQUEUE_PUSH(T)` shall return `TQUEUE_PUSH_QUEUE_FULL`.
+- **SRS_TQUEUE_01_016: [** `TQUEUE_PUSH(T)` shall obtain the current tail queue by calling `interlocked_add_64`. **]**
 
-- If the state of the array entry corresponding to the head is not `NOT_USED`, `TQUEUE_PUSH(T)` shall try again.
+- **SRS_TQUEUE_01_022: [** If the queue is full (current head >= current tail + queue size), `TQUEUE_PUSH(T)` shall return `TQUEUE_PUSH_QUEUE_FULL`. **]**
 
-- Part of the same `interlocked_compare_exchange` as above, if the state of the array entry corresponding to the head is `NOT_USED`:
+- **SRS_TQUEUE_01_018: [** Using `interlocked_compare_exchange_64`, `TQUEUE_PUSH(T)` shall replace the head value with the head value obtained earlier + 1. **]**
 
-  - `TQUEUE_PUSH(T)` shall set the state to `PUSHING` (from `NOT_USED`) by using `interlocked_compare_exchange`.
+- **SRS_TQUEUE_01_043: [** If the queue head has changed, `TQUEUE_PUSH(T)` shall try again. **]**
 
-  - `TQUEUE_PUSH(T)` shall replace the head value with the head value obtained earlier + 1 by using `interlocked_exchange_64`.
+- **SRS_TQUEUE_01_017: [** Using `interlocked_compare_exchange`, `TQUEUE_PUSH(T)` shall change the head array entry state to `PUSHING` (from `NOT_USED`). **]**
 
-  - If no `push_cb_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall copy the value of `item` into the array entry value whose state was changed to `PUSHING`.
+  - **SRS_TQUEUE_01_023: [** If the state of the array entry corresponding to the head is not `NOT_USED`, `TQUEUE_PUSH(T)` shall try changing the state again. **]**
 
-  - If a `push_cb_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall call the `push_cb_function` with `push_cb_function_context` as `context`, a pointer to the array entry value whose state was changed to `PUSHING` as `push_dst` and `item` as `push_src`.
+- **SRS_TQUEUE_01_019: [** If no `push_cb_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall copy the value of `item` into the array entry value whose state was changed to `PUSHING`. **]**
 
-  - `TQUEUE_PUSH(T)` shall set the state to `USED` by using `interlocked_exchange`.
+- **SRS_TQUEUE_01_024: [** If a `push_cb_function` was specified in `TQUEUE_CREATE(T)`, `TQUEUE_PUSH(T)` shall call the `push_cb_function` with `push_cb_function_context` as `context`, a pointer to the array entry value whose state was changed to `PUSHING` as `push_dst` and `item` as `push_src`. **]**
 
-  - `TQUEUE_PUSH(T)` shall succeed and return `TQUEUE_PUSH_OK`.
+- **SRS_TQUEUE_01_020: [** `TQUEUE_PUSH(T)` shall set the state to `USED` by using `interlocked_exchange`. **]**
+
+- **SRS_TQUEUE_01_021: [** `TQUEUE_PUSH(T)` shall succeed and return `TQUEUE_PUSH_OK`. **]**
 
 ### TQUEUE_POP(T)
 ```c
-TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* pop_cb_function_context)
+TQUEUE_POP_RESULT TQUEUE_POP(T)(TQUEUE(T) tqueue, T* item, void* pop_function_context, TQUEUE_CONDITION_FUNC(T), condition_function, void*, condition_function_context);
 ```
 
 `TQUEUE_POP(T)` pops an item from the queue if available.
 
-If `tqueue` is `NULL` then `TQUEUE_POP(T)` shall fail and return `TQUEUE_POP_INVALID_ARG`.
+**SRS_TQUEUE_01_025: [** If `tqueue` is `NULL` then `TQUEUE_POP(T)` shall fail and return `TQUEUE_POP_INVALID_ARG`. **]**
 
-`TQUEUE_POP(T)` shall execute the following actions until it is either able to pop the item from the queue or the queue is empty:
+**SRS_TQUEUE_01_027: [** If `item` is `NULL` then `TQUEUE_POP(T)` shall fail and return `TQUEUE_POP_INVALID_ARG`. **]**
 
-- `TQUEUE_POP(T)` shall obtain the current head queue by calling `interlocked_add_64`.
+**SRS_TQUEUE_01_026: [** `TQUEUE_POP(T)` shall execute the following actions until it is either able to pop the item from the queue or the queue is empty: **]**
 
-- `TQUEUE_POP(T)` shall obtain the current tail queue by calling `interlocked_add_64`.
+- **SRS_TQUEUE_01_028: [** `TQUEUE_POP(T)` shall obtain the current head queue by calling `interlocked_add_64`. **]**
 
-- If the queue is empty (current tail == current head), `TQUEUE_POP(T)` shall return `TQUEUE_POP_QUEUE_EMPTY`.
+- **SRS_TQUEUE_01_029: [** `TQUEUE_POP(T)` shall obtain the current tail queue by calling `interlocked_add_64`. **]**
 
-- If the state of the array entry corresponding to the tail is not `USED`, `TQUEUE_POP(T)` shall try again.
+- **SRS_TQUEUE_01_035: [** If the queue is empty (current tail == current head), `TQUEUE_POP(T)` shall return `TQUEUE_POP_QUEUE_EMPTY`. **]**
 
-- Part of the same `interlocked_compare_exchange` as above, if the state of the array entry corresponding to the tail is `USED`:
+- **SRS_TQUEUE_01_030: [** Using `interlocked_compare_exchange`, `TQUEUE_PUSH(T)` shall set the tail array entry state to `POPPING` (from `USED`). **]**
 
-  - `TQUEUE_POP(T)` shall set the state to `POPPING` (from `USED`).
+  - **SRS_TQUEUE_01_036: [** If the state of the array entry corresponding to the tail is not `USED`, `TQUEUE_POP(T)` shall try again. **]**
 
-  - If a `pop_cb_function` was not specified in `TQUEUE_CREATE(T)`:
+  - **SRS_TQUEUE_01_039: [** If `condition_function` is not `NULL`: **]**
+
+    - **SRS_TQUEUE_01_040: [** `TQUEUE_POP(T)` shall call `condition_function` with `condition_function_context` and a pointer to the array entry value whose state was changed to `POPPING`. **]**
+
+    - **SRS_TQUEUE_01_041: [** If `condition_function` returns `false`, `TQUEUE_POP(T)` shall set the state to `USED` by using `interlocked_exchange` and return `TQUEUE_POP_REJECTED`. **]**
+
+    - **SRS_TQUEUE_01_042: [** Otherwise, shall proceed with the pop. **]**
+
+  - **SRS_TQUEUE_01_031: [** `TQUEUE_POP(T)` shall replace the tail value with the tail value obtained earlier + 1 by using `interlocked_compare_exchange_64`. **]**
+
+    - **SRS_TQUEUE_01_044: [** If incrementing the tail by using `interlocked_compare_exchange_64` does not succeed, `TQUEUE_POP(T)` shall revert the state of the array entry to `USED` and retry. **]**
+
+  - **SRS_TQUEUE_01_032: [** If a `pop_cb_function` was not specified in `TQUEUE_CREATE(T)`: **]**
   
-    - `TQUEUE_POP(T)` shall replace the tail value with the tail value obtained earlier + 1 by using `interlocked_exchange_64`.
+    - **SRS_TQUEUE_01_033: [** `TQUEUE_POP(T)` shall copy array entry value whose state was changed to `POPPING` to `item`. **]**
 
-    - `TQUEUE_POP(T)` shall copy array entry value whose state was changed to `POPPING` to `item`.
-
-    - `TQUEUE_POP(T)` shall set the state to `NOT_USED` by using `interlocked_exchange`, succeed and return `TQUEUE_POP_OK`.
-
-  - If a `pop_cb_function` was specified in `TQUEUE_CREATE(T)`:
+  - **SRS_TQUEUE_01_037: [** If a `pop_cb_function` was specified in `TQUEUE_CREATE(T)`: **]**
   
-    - `TQUEUE_POP(T)` shall call `pop_cb_function` with `pop_cb_function_context` as `context`, the array entry value whose state was changed to `POPPING` to `item` as `pop_src` and `item` as `pop_dst`.
+    - **SRS_TQUEUE_01_038: [** `TQUEUE_POP(T)` shall call `pop_cb_function` with `pop_cb_function_context` as `context`, the array entry value whose state was changed to `POPPING` to `item` as `pop_src` and `item` as `pop_dst`. **]**
 
-    - If `pop_cb_function` returns `TQUEUE_POP_CB_FUNCTION_OK`:
-
-      - `TQUEUE_POP(T)` shall replace the tail value with the tail value obtained earlier + 1 by using `interlocked_exchange_64`.
-    
-      - `TQUEUE_POP(T)` shall set the state to `NOT_USED` by using `interlocked_exchange`, succeed and return `TQUEUE_POP_OK`.
-
-    - If `pop_cb_function` returns `TQUEUE_POP_CB_FUNCTION_POP_REJECTED`, `TQUEUE_POP(T)` shall set the state to `USED` by using `interlocked_exchange` and return `TQUEUE_POP_REJECTED`.
+  - **SRS_TQUEUE_01_034: [** `TQUEUE_POP(T)` shall set the state to `NOT_USED` by using `interlocked_exchange`, succeed and return `TQUEUE_POP_OK`. **]**

--- a/inc/clds/tqueue.h
+++ b/inc/clds/tqueue.h
@@ -10,10 +10,46 @@
 
 #include "umock_c/umock_c_prod.h"
 
-/*macro to be used in headers*/                                                                                             \
-#define TQUEUE_TYPE_DECLARE(T, ...)                                                                                         \
+/*TQUEUE is-a THANDLE.*/
+/*given a type "T" TQUEUE(T) expands to the name of the type. */
+#define TQUEUE(T) TQUEUE_LL(T)
 
-/*macro to be used in .c*/                                                                                                  \
-#define TQUEUE_TYPE_DEFINE(T, ...)                                                                                          \
+#define TQUEUE_CREATE_DECLARE(T) TQUEUE_LL_CREATE_DECLARE(T, T)
+#define TQUEUE_PUSH_DECLARE(T) TQUEUE_LL_PUSH_DECLARE(T, T)
+#define TQUEUE_POP_DECLARE(T) TQUEUE_LL_POP_DECLARE(T, T)
+
+#define TQUEUE_CREATE_DEFINE(T) TQUEUE_LL_CREATE_DEFINE(T, T)
+#define TQUEUE_PUSH_DEFINE(T) TQUEUE_LL_PUSH_DEFINE(T, T)
+#define TQUEUE_POP_DEFINE(T) TQUEUE_LL_POP_DEFINE(T, T)
+
+#define TQUEUE_FREE_DEFINE(T) TQUEUE_LL_FREE_DEFINE(T, T)
+
+#define TQUEUE_CREATE(C) TQUEUE_LL_CREATE(C)
+
+#define TQUEUE_PUSH(C) TQUEUE_LL_PUSH(C)
+#define TQUEUE_POP(C) TQUEUE_LL_POP(C)
+
+#define TQUEUE_INITIALIZE(T) TQUEUE_LL_INITIALIZE(T)
+#define TQUEUE_ASSIGN(T) TQUEUE_LL_ASSIGN(T)
+#define TQUEUE_MOVE(T) TQUEUE_LL_MOVE(T)
+#define TQUEUE_INITIALIZE_MOVE(T) TQUEUE_LL_INITIALIZE_MOVE(T)
+
+#define TQUEUE_TARGET_HANDLE(T) TQUEUE_LL_TARGET_HANDLE(T)
+#define TQUEUE_TARGET_FUNC(T) TQUEUE_LL_TARGET_FUNC(T)
+
+/*macro to be used in headers*/                                                                                     \
+#define TQUEUE_TYPE_DECLARE(T, ...)                                                                                 \
+    /*hint: have TQUEUE_DEFINE_TYPE(T) before TQUEUE_TYPE_DECLARE                               */                  \
+    /*hint: have THANDLE_TYPE_DECLARE(TQUEUE_TYPEDEF_NAME(T)) before TQUEUE_TYPE_DECLARE               */           \
+    TQUEUE_CREATE_DECLARE(T)                                                                                        \
+    TQUEUE_PUSH_DECLARE(T)                                                                                          \
+    TQUEUE_POP_DECLARE(T)                                                                                           \
+
+#define TQUEUE_TYPE_DEFINE(T, ...)                                                                                  \
+    /*hint: have THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(T)) before  TQUEUE_TYPE_DEFINE                */           \
+    TQUEUE_FREE_DEFINE(T)                                                                                           \
+    TQUEUE_CREATE_DEFINE(T)                                                                                         \
+    TQUEUE_PUSH_DEFINE(T)                                                                                           \
+    TQUEUE_POP_DEFINE(T)                                                                                            \
 
 #endif // TQUEUE_H

--- a/inc/clds/tqueue_ll.h
+++ b/inc/clds/tqueue_ll.h
@@ -4,6 +4,16 @@
 #ifndef TQUEUE_LL_H
 #define TQUEUE_LL_H
 
+#ifdef __cplusplus
+#include <cstdbool>
+#include <cinttypes>
+#else // __cplusplus
+#include <stdbool.h>
+#include <inttypes.h>
+#endif // __cplusplus
+
+#include "c_pal/interlocked.h"
+
 #include "c_pal/thandle_ll.h"
 
 #include "umock_c/umock_c_prod.h"
@@ -23,17 +33,368 @@ MU_DEFINE_ENUM(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_RESULT_VALUES);
 
 MU_DEFINE_ENUM(TQUEUE_POP_RESULT, TQUEUE_POP_RESULT_VALUES);
 
-#define TQUEUE_POP_CB_FUNCTION_RESULT_VALUES \
-    TQUEUE_POP_CB_FUNCTION_OK, \
-    TQUEUE_POP_CB_FUNCTION_POP_REJECTED
+#define QUEUE_ENTRY_STATE_VALUES \
+    QUEUE_ENTRY_STATE_NOT_USED, \
+    QUEUE_ENTRY_STATE_PUSHING, \
+    QUEUE_ENTRY_STATE_USED, \
+    QUEUE_ENTRY_STATE_POPPING \
 
-MU_DEFINE_ENUM(TQUEUE_POP_CB_FUNCTION_RESULT, TQUEUE_POP_CB_FUNCTION_RESULT_VALUES);
+MU_DEFINE_ENUM(QUEUE_ENTRY_STATE, QUEUE_ENTRY_STATE_VALUES);
 
-/*macro to be used in headers*/                                                                                         \
-#define TQUEUE_LL_TYPE_DECLARE(C, T, ...)                                                                               \
-    /*hint: have TQUEUE_DEFINE_STRUCT_TYPE(T) before TQUEUE_LL_TYPE_DECLARE*/                                           \
+/*TQUEUE is backed by a THANDLE build on the structure below*/
+#define TQUEUE_STRUCT_TYPE_NAME_TAG(T) MU_C2(TQUEUE_TYPEDEF_NAME(T), _TAG)
+#define TQUEUE_TYPEDEF_NAME(T) MU_C2(TQUEUE_STRUCT_, T)
 
-/*macro to be used in .c*/                                                                                              \
-#define TQUEUE_LL_TYPE_DEFINE(C, T, ...)                                                                                \
+#define TQUEUE_ENTRY_STRUCT_TYPE_NAME_TAG(T) MU_C2(TQUEUE_ENTRY_STRUCT_TYPE_NAME(T), _TAG)
+#define TQUEUE_ENTRY_STRUCT_TYPE_NAME(T) MU_C2(TQUEUE_ENTRY_STRUCT_, T)
+
+/* This introduces the name for the push cb function */
+#define TQUEUE_DEFINE_PUSH_CB_FUNCTION_TYPE_NAME(T) MU_C2(TQUEUE_PUSH_CB_FUNC_TYPE_, T)
+#define TQUEUE_PUSH_CB_FUNC(T) TQUEUE_DEFINE_PUSH_CB_FUNCTION_TYPE_NAME(T)
+
+/* This introduces the name for the pop cb function */
+#define TQUEUE_DEFINE_POP_CB_FUNCTION_TYPE_NAME(T) MU_C2(TQUEUE_POP_CB_FUNC_TYPE_, T)
+#define TQUEUE_POP_CB_FUNC(T) TQUEUE_DEFINE_POP_CB_FUNCTION_TYPE_NAME(T)
+
+/* This introduces the name for the dispose item function */
+#define TQUEUE_DEFINE_DISPOSE_ITEM_FUNCTION_TYPE_NAME(T) MU_C2(TQUEUE_DISPOSE_ITEM_FUNC_TYPE_, T)
+#define TQUEUE_DISPOSE_ITEM_FUNC(T) TQUEUE_DEFINE_DISPOSE_ITEM_FUNCTION_TYPE_NAME(T)
+
+/* This introduces the name for the pop condition function */
+#define TQUEUE_DEFINE_CONDITION_FUNCTION_TYPE_NAME(T) MU_C2(TQUEUE_CONDITION_FUNC_TYPE_, T)
+#define TQUEUE_CONDITION_FUNC(T) TQUEUE_DEFINE_CONDITION_FUNCTION_TYPE_NAME(T)
+
+/*TQUEUE_DEFINE_STRUCT_TYPE(T) introduces the base type that holds the queue typed as T*/
+#define TQUEUE_DEFINE_STRUCT_TYPE(T)                                                                            \
+typedef void (*TQUEUE_DEFINE_PUSH_CB_FUNCTION_TYPE_NAME(T))(void* context, T* push_dst, T* push_src);           \
+typedef void (*TQUEUE_DEFINE_POP_CB_FUNCTION_TYPE_NAME(T))(void* context, T* pop_dst, T* pop_src);              \
+typedef void (*TQUEUE_DEFINE_DISPOSE_ITEM_FUNCTION_TYPE_NAME(T))(void* context, T* item);                       \
+typedef bool (*TQUEUE_DEFINE_CONDITION_FUNCTION_TYPE_NAME(T))(void* context, T* item);                          \
+typedef struct TQUEUE_ENTRY_STRUCT_TYPE_NAME_TAG(T)                                                             \
+{                                                                                                               \
+    volatile_atomic int32_t state;                                                                              \
+    T value;                                                                                                    \
+} TQUEUE_ENTRY_STRUCT_TYPE_NAME(T);                                                                             \
+typedef struct TQUEUE_STRUCT_TYPE_NAME_TAG(T)                                                                   \
+{                                                                                                               \
+    volatile_atomic int64_t head;                                                                               \
+    volatile_atomic int64_t tail;                                                                               \
+    TQUEUE_PUSH_CB_FUNC(T) push_cb_function;                                                                    \
+    TQUEUE_POP_CB_FUNC(T) pop_cb_function;                                                                      \
+    TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function;                                                          \
+    void* dispose_item_function_context;                                                                        \
+    uint32_t queue_size;                                                                                        \
+    TQUEUE_ENTRY_STRUCT_TYPE_NAME(T) queue[];                                                                   \
+} TQUEUE_TYPEDEF_NAME(T);                                                                                       \
+
+/*TQUEUE is-a THANDLE*/
+/*given a type "T" TQUEUE_LL(T) expands to the name of the type. */
+#define TQUEUE_LL(T) THANDLE(TQUEUE_TYPEDEF_NAME(T))
+
+/*because TQUEUE is a THANDLE, all THANDLE's macro APIs are useable with TQUEUE.*/
+/*the below are just shortcuts of THANDLE's public ones*/
+#define TQUEUE_LL_INITIALIZE(T) THANDLE_INITIALIZE(TQUEUE_TYPEDEF_NAME(T))
+#define TQUEUE_LL_ASSIGN(T) THANDLE_ASSIGN(TQUEUE_TYPEDEF_NAME(T))
+#define TQUEUE_LL_MOVE(T) THANDLE_MOVE(TQUEUE_TYPEDEF_NAME(T))
+#define TQUEUE_LL_INITIALIZE_MOVE(T) THANDLE_INITIALIZE_MOVE(TQUEUE_TYPEDEF_NAME(T))
+
+/*introduces a new name for a function that returns a TQUEUE_LL(T)*/
+#define TQUEUE_LL_CREATE_NAME(C) MU_C2(TQUEUE_LL_CREATE_, C)
+#define TQUEUE_LL_CREATE(C) TQUEUE_LL_CREATE_NAME(C)
+
+/*introduces a new name for the push function */
+#define TQUEUE_LL_PUSH_NAME(C) MU_C2(TQUEUE_LL_PUSH_, C)
+#define TQUEUE_LL_PUSH(C) TQUEUE_LL_PUSH_NAME(C)
+
+/*introduces a new name for the pop function */
+#define TQUEUE_LL_POP_NAME(C) MU_C2(TQUEUE_LL_POP_, C)
+#define TQUEUE_LL_POP(C) TQUEUE_LL_POP_NAME(C)
+
+/*introduces a function declaration for tqueue_create*/
+#define TQUEUE_LL_CREATE_DECLARE(C, T) MOCKABLE_FUNCTION(, TQUEUE_LL(T), TQUEUE_LL_CREATE(C), uint32_t, queue_size, TQUEUE_PUSH_CB_FUNC(T), push_cb_function, TQUEUE_POP_CB_FUNC(T), pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(T), dispose_item_function, void*, dispose_item_function_context);
+
+/*introduces a function declaration for tqueue_push*/
+#define TQUEUE_LL_PUSH_DECLARE(C, T) MOCKABLE_FUNCTION(, TQUEUE_PUSH_RESULT, TQUEUE_LL_PUSH(C), TQUEUE_LL(T), tqueue, T*, item, void*, push_cb_function_context);
+
+/*introduces a function declaration for tqueue_pop*/
+#define TQUEUE_LL_POP_DECLARE(C, T) MOCKABLE_FUNCTION(, TQUEUE_POP_RESULT, TQUEUE_LL_POP(C), TQUEUE_LL(T), tqueue, T*, item, void*, pop_cb_function_context, TQUEUE_CONDITION_FUNC(T), condition_function, void*, condition_function_context);
+
+/*introduces a name for the function that free's a TQUEUE when it's ref count got to 0*/
+#define TQUEUE_LL_FREE_NAME(C) MU_C2(TQUEUE_LL_FREE_, C)
+
+/*introduces a function definition for freeing the allocated resources for a TQUEUE*/
+#define TQUEUE_LL_FREE_DEFINE(C, T) \
+static void TQUEUE_LL_FREE_NAME(C)(TQUEUE_TYPEDEF_NAME(T)* tqueue)                                                                                                  \
+{                                                                                                                                                                   \
+    if (tqueue == NULL)                                                                                                                                             \
+    {                                                                                                                                                               \
+        LogError("invalid arguments " MU_TOSTRING(TQUEUE_TYPEDEF_NAME(T)) "* tqueue=%p",                                                                            \
+            tqueue);                                                                                                                                                \
+    }                                                                                                                                                               \
+    else                                                                                                                                                            \
+    {                                                                                                                                                               \
+        if (tqueue->dispose_item_function == NULL)                                                                                                                  \
+        {                                                                                                                                                           \
+            /* Codes_SRS_TQUEUE_01_008: [ If dispose_item_function passed to TQUEUE_CREATE(T) is NULL, TQUEUE_DISPOSE_FUNC(T) shall return. ]*/                     \
+        }                                                                                                                                                           \
+        else                                                                                                                                                        \
+        {                                                                                                                                                           \
+            /* Codes_SRS_TQUEUE_01_009: [ Otherwise, TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue head by calling interlocked_add_64. ]*/                  \
+            int64_t current_head = interlocked_add_64((volatile_atomic int64_t*)&tqueue->head, 0);                                                                  \
+            /* Codes_SRS_TQUEUE_01_010: [ TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue tail by calling interlocked_add_64. ]*/                             \
+            int64_t current_tail = interlocked_add_64((volatile_atomic int64_t*)&tqueue->tail, 0);                                                                  \
+            for (int64_t pos = current_tail; pos < current_head; pos++)                                                                                             \
+            {                                                                                                                                                       \
+                uint32_t index = (uint32_t)(pos % tqueue->queue_size);                                                                                              \
+                /* Codes_SRS_TQUEUE_01_011: [ For each item in the queue, dispose_item_function shall be called with dispose_function_context and a pointer to the array entry value (T*). ]*/ \
+                tqueue->dispose_item_function(tqueue->dispose_item_function_context, &tqueue->queue[index].value);                                                  \
+            }                                                                                                                                                       \
+        }                                                                                                                                                           \
+    }                                                                                                                                                               \
+}                                                                                                                                                                   \
+
+/*introduces a function definition for tqueue_create*/
+#define TQUEUE_LL_CREATE_DEFINE(C, T)                                                                                                                     \
+TQUEUE_LL(T) TQUEUE_LL_CREATE(C)(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(T) push_cb_function, TQUEUE_POP_CB_FUNC(T) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(T) dispose_item_function, void* dispose_item_function_context) \
+{                                                                                                                                                                   \
+    TQUEUE_TYPEDEF_NAME(T)* result;                                                                                                                                 \
+    bool is_push_cb_function_NULL = (push_cb_function == NULL);                                                                                                     \
+    bool is_pop_cb_function_NULL = (pop_cb_function == NULL);                                                                                                       \
+    bool is_dispose_item_function_NULL = (dispose_item_function == NULL);                                                                                           \
+    if (                                                                                                                                                            \
+        /* Codes_SRS_TQUEUE_01_001: [ If queue_size is 0, TQUEUE_CREATE(T) shall fail and return NULL. ]*/                                                          \
+        (queue_size == 0) ||                                                                                                                                        \
+        /* Codes_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/ \
+        ((is_push_cb_function_NULL || is_pop_cb_function_NULL || is_dispose_item_function_NULL) &&                                                                  \
+         !(is_push_cb_function_NULL && is_pop_cb_function_NULL && is_dispose_item_function_NULL))                                                                   \
+       )                                                                                                                                                            \
+    {                                                                                                                                                               \
+        LogError("Invalid arguments: uint32_t queue_size=%" PRIu32 ", " MU_TOSTRING(TQUEUE_PUSH_CB_FUNC(T)) " push_cb_function=%p," MU_TOSTRING(TQUEUE_POP_CB_FUNC(T)) " pop_cb_function=%p, " MU_TOSTRING(TQUEUE_DISPOSE_ITEM_FUNC(T)) " dispose_item_function=%p, void* dispose_item_function_context=%p", \
+            queue_size, push_cb_function, pop_cb_function, dispose_item_function, dispose_item_function_context);                                                        \
+        result = NULL;                                                                                                                                              \
+    }                                                                                                                                                               \
+    else                                                                                                                                                            \
+    {                                                                                                                                                               \
+        /* Codes_SRS_TQUEUE_01_003: [ TQUEUE_CREATE(T) shall call THANDLE_MALLOC_FLEX with TQUEUE_DISPOSE_FUNC(T) as dispose function, nmemb set to queue_size and size set to sizeof(T). ]*/ \
+        result = THANDLE_MALLOC_FLEX(TQUEUE_TYPEDEF_NAME(C))(TQUEUE_LL_FREE_NAME(C), queue_size, sizeof(TQUEUE_ENTRY_STRUCT_TYPE_NAME(T)));                         \
+        if(result == NULL)                                                                                                                                          \
+        {                                                                                                                                                           \
+            /* Codes_SRS_TQUEUE_01_007: [ If there are any failures then TQUEUE_CREATE(T) shall fail and return NULL. ]*/                                           \
+            LogError("failure in " MU_TOSTRING(THANDLE_MALLOC_FLEX) "(sizeof(" MU_TOSTRING(TQUEUE_TYPEDEF_NAME(C)) ")=%zu, queue_size=%" PRIu32 ", sizeof(" MU_TOSTRING(TQUEUE_ENTRY_STRUCT_TYPE_NAME(T)) ")=%zu)", \
+                sizeof(TQUEUE_TYPEDEF_NAME(C)), queue_size, sizeof(TQUEUE_ENTRY_STRUCT_TYPE_NAME(T)));                                                              \
+            /*return as is*/                                                                                                                                        \
+        }                                                                                                                                                           \
+        else                                                                                                                                                        \
+        {                                                                                                                                                           \
+            result->queue_size = queue_size;                                                                                                                        \
+            result->push_cb_function = push_cb_function;                                                                                                                        \
+            result->pop_cb_function = pop_cb_function;                                                                                                                        \
+            result->dispose_item_function = dispose_item_function;                                                                                                                        \
+            result->dispose_item_function_context = dispose_item_function_context;                                                                                                                        \
+            /* Codes_SRS_TQUEUE_01_004: [ TQUEUE_CREATE(T) shall initialize the head and tail of the list with 0 by using interlocked_exchange_64. ]*/              \
+            (void)interlocked_exchange_64(&result->head, 0);                                                                                                        \
+            (void)interlocked_exchange_64(&result->tail, 0);                                                                                                        \
+            for (uint32_t i = 0; i < queue_size; i++)                                                                                                               \
+            {                                                                                                                                                       \
+                /* Codes_SRS_TQUEUE_01_005: [ TQUEUE_CREATE(T) shall initialize the state for each entry in the array used for the queue with NOT_USED by using interlocked_exchange. ]*/ \
+                (void)interlocked_exchange(&result->queue[i].state, QUEUE_ENTRY_STATE_NOT_USED);                                                                    \
+            }                                                                                                                                                       \
+            /* Codes_SRS_TQUEUE_01_006: [ TQUEUE_CREATE(T) shall succeed and return a non-NULL value. ]*/                                                           \
+            /*return as is*/                                                                                                                                        \
+        }                                                                                                                                                           \
+    }                                                                                                                                                               \
+    return result;                                                                                                                                                  \
+}
+
+/*introduces a function definition for tqueue_push*/
+#define TQUEUE_LL_PUSH_DEFINE(C, T)                                                                                                                                 \
+TQUEUE_PUSH_RESULT TQUEUE_LL_PUSH(C)(TQUEUE_LL(T) tqueue, T* item, void* push_cb_function_context)                                                                  \
+{                                                                                                                                                                   \
+    TQUEUE_PUSH_RESULT result;                                                                                                                                      \
+    if (                                                                                                                                                            \
+        /* Codes_SRS_TQUEUE_01_012: [ If tqueue is NULL then TQUEUE_PUSH(T) shall fail and return TQUEUE_PUSH_INVALID_ARG. ]*/                                      \
+        (tqueue == NULL) ||                                                                                                                                         \
+        /* Codes_SRS_TQUEUE_01_013: [ If item is NULL then TQUEUE_PUSH(T) shall fail and return TQUEUE_PUSH_INVALID_ARG. ]*/                                        \
+        (item == NULL)                                                                                                                                              \
+       )                                                                                                                                                            \
+    {                                                                                                                                                               \
+        LogError("Invalid arguments: TQUEUE_LL(" MU_TOSTRING(T) ") tqueue=%p, const " MU_TOSTRING(T) "* item=%p, void* push_cb_function_context=%p",                \
+            tqueue, item, push_cb_function_context);                                                                                                                \
+        result = TQUEUE_PUSH_INVALID_ARG;                                                                                                                           \
+    }                                                                                                                                                               \
+    else                                                                                                                                                            \
+    {                                                                                                                                                               \
+        /* Codes_SRS_TQUEUE_01_014: [ TQUEUE_PUSH(T) shall execute the following actions until it is either able to push the item in the queue or the queue is full: ]*/ \
+        do                                                                                                                                                          \
+        {                                                                                                                                                           \
+            /* Codes_SRS_TQUEUE_01_015: [ TQUEUE_PUSH(T) shall obtain the current head queue by calling interlocked_add_64. ]*/                                     \
+            int64_t current_head = interlocked_add_64((volatile_atomic int64_t*)&tqueue->head, 0);                                                                  \
+            /* Codes_SRS_TQUEUE_01_016: [ TQUEUE_PUSH(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/                                     \
+            int64_t current_tail = interlocked_add_64((volatile_atomic int64_t*)&tqueue->tail, 0);                                                                  \
+            if (current_head >= current_tail + tqueue->queue_size)                                                                                                  \
+            {                                                                                                                                                       \
+                /* Codes_SRS_TQUEUE_01_022: [ If the queue is full (current head >= current tail + queue size), TQUEUE_PUSH(T) shall return TQUEUE_PUSH_QUEUE_FULL. ]*/ \
+                result = TQUEUE_PUSH_QUEUE_FULL;                                                                                                                    \
+                break;                                                                                                                                              \
+            }                                                                                                                                                       \
+            else                                                                                                                                                    \
+            {                                                                                                                                                       \
+                /* Codes_SRS_TQUEUE_01_018: [ Using interlocked_compare_exchange_64, TQUEUE_PUSH(T) shall replace the head value with the head value obtained earlier + 1. ]*/ \
+                if (interlocked_compare_exchange_64((volatile_atomic int64_t*)&tqueue->head, current_head + 1, current_head) != current_head)                       \
+                {                                                                                                                                                   \
+                    /* Codes_SRS_TQUEUE_01_043: [ If the queue head has changed, TQUEUE_PUSH(T) shall try again. ]*/                                                \
+                    continue;                                                                                                                                       \
+                }                                                                                                                                                   \
+                else                                                                                                                                                \
+                {                                                                                                                                                   \
+                    uint32_t index = (uint32_t)current_head  % tqueue->queue_size;                                                                                  \
+                    do                                                                                                                                              \
+                    {                                                                                                                                               \
+                        /* Codes_SRS_TQUEUE_01_017: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall change the head array entry state to PUSHING (from NOT_USED). ]*/ \
+                        if (interlocked_compare_exchange((volatile_atomic int32_t*) & tqueue->queue[index].state, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED) != QUEUE_ENTRY_STATE_NOT_USED) \
+                        {                                                                                                                                           \
+                            /* changed */                                                                                                                           \
+                            /* Codes_SRS_TQUEUE_01_023: [ If the state of the array entry corresponding to the head is not NOT_USED, TQUEUE_PUSH(T) shall try changing the state again. ]*/ \
+                        }                                                                                                                                           \
+                        else                                                                                                                                        \
+                        {                                                                                                                                           \
+                            break;                                                                                                                                  \
+                        }                                                                                                                                           \
+                    } while (1);                                                                                                                                    \
+                                                                                                                                                                    \
+                    if (tqueue->push_cb_function == NULL)                                                                                                           \
+                    {                                                                                                                                               \
+                        /* Codes_SRS_TQUEUE_01_019: [ If no push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall copy the value of item into the array entry value whose state was changed to PUSHING. ]*/ \
+                        (void)memcpy((void*)(T*)&tqueue->queue[index].value, (void*)item, sizeof(T));                                                               \
+                    }                                                                                                                                               \
+                    else                                                                                                                                            \
+                    {                                                                                                                                               \
+                        /* Codes_SRS_TQUEUE_01_024: [ If a push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall call the push_cb_function with push_cb_function_context as context, a pointer to the array entry value whose state was changed to PUSHING as push_dst and item as push_src. ] */ \
+                        tqueue->push_cb_function(push_cb_function_context, (T*)&tqueue->queue[index].value, item);                                                  \
+                    }                                                                                                                                               \
+                    /* Codes_SRS_TQUEUE_01_020: [ TQUEUE_PUSH(T) shall set the state to USED by using interlocked_exchange. ]*/                                     \
+                    (void)interlocked_exchange((volatile_atomic int32_t*)&tqueue->queue[index].state, QUEUE_ENTRY_STATE_USED);                                      \
+                    /* Codes_SRS_TQUEUE_01_021: [ TQUEUE_PUSH(T) shall succeed and return TQUEUE_PUSH_OK. ]*/                                                       \
+                    result = TQUEUE_PUSH_OK;                                                                                                                        \
+                    break;                                                                                                                                          \
+                }                                                                                                                                                   \
+            }                                                                                                                                                       \
+        } while (1);                                                                                                                                                \
+    }                                                                                                                                                               \
+    return result;                                                                                                                                                  \
+}                                                                                                                                                                   \
+
+/*introduces a function definition for tqueue_pop*/
+#define TQUEUE_LL_POP_DEFINE(C, T)                                                                                                                                  \
+TQUEUE_POP_RESULT TQUEUE_LL_POP(C)(TQUEUE_LL(T) tqueue, T* item, void* pop_cb_function_context, TQUEUE_CONDITION_FUNC(T) condition_function, void* condition_function_context) \
+{                                                                                                                                                                   \
+    TQUEUE_POP_RESULT result;                                                                                                                                                     \
+    if (                                                                                                                                                            \
+        /* Codes_SRS_TQUEUE_01_025: [ If tqueue is NULL then TQUEUE_POP(T) shall fail and return TQUEUE_POP_INVALID_ARG. ]*/                                        \
+        (tqueue == NULL) ||                                                                                                                                         \
+        /* Codes_SRS_TQUEUE_01_027: [ If item is NULL then TQUEUE_POP(T) shall fail and return TQUEUE_POP_INVALID_ARG. ]*/                                          \
+        (item == NULL)                                                                                                                                              \
+       )                                                                                                                                                            \
+    {                                                                                                                                                               \
+        LogError("Invalid arguments: TQUEUE_LL(" MU_TOSTRING(T) ") tqueue=%p, " MU_TOSTRING(T) "*=%p, void* pop_cb_function_context, TQUEUE_CONDITION_FUNC(T) condition_function, void* condition_function_context", \
+            tqueue, item);                                                                                                                                          \
+        result = TQUEUE_POP_INVALID_ARG;                                                                                                                                        \
+    }                                                                                                                                                               \
+    else                                                                                                                                                            \
+    {                                                                                                                                                               \
+        /* Codes_SRS_TQUEUE_01_026: [ TQUEUE_POP(T) shall execute the following actions until it is either able to pop the item from the queue or the queue is empty: ] */ \
+        do                                                                                                                                                          \
+        {                                                                                                                                                           \
+            /* Codes_SRS_TQUEUE_01_028: [ TQUEUE_POP(T) shall obtain the current head queue by calling interlocked_add_64. ]*/                                      \
+            int64_t current_head = interlocked_add_64((volatile_atomic int64_t*)&tqueue->head, 0);                                                                  \
+            /* Codes_SRS_TQUEUE_01_029: [ TQUEUE_POP(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/                                      \
+            int64_t current_tail = interlocked_add_64((volatile_atomic int64_t*)&tqueue->tail, 0);                                                                  \
+            if (current_tail >= current_head)                                                                                                                       \
+            {                                                                                                                                                       \
+                /* Codes_SRS_TQUEUE_01_035: [ If the queue is empty (current tail == current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/          \
+                result = TQUEUE_POP_QUEUE_EMPTY;                                                                                                                    \
+                break;                                                                                                                                              \
+            }                                                                                                                                                       \
+            else                                                                                                                                                    \
+            {                                                                                                                                                       \
+                /* LogInfo("Popping from %" PRId64 "", current_tail); */ \
+                /* Codes_SRS_TQUEUE_01_030: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall set the tail array entry state to POPPING (from USED). ]*/   \
+                uint32_t index = (uint32_t)current_tail % tqueue->queue_size;                                                                                       \
+                if (interlocked_compare_exchange((volatile_atomic int32_t*)&tqueue->queue[index].state, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED) != QUEUE_ENTRY_STATE_USED) \
+                {                                                                                                                                                   \
+                    /* Codes_SRS_TQUEUE_01_036: [ If the state of the array entry corresponding to the tail is not USED, TQUEUE_POP(T) shall try again. ]*/         \
+                    continue;                                                                                                                                       \
+                }                                                                                                                                                   \
+                else                                                                                                                                                \
+                {                                                                                                                                                   \
+                    bool should_pop;                                                                                                                                \
+                    /* Codes_SRS_TQUEUE_01_039: [ If condition_function is not NULL: ]*/                                                                            \
+                    if (condition_function != NULL)                                                                                                                 \
+                    {                                                                                                                                               \
+                        /* Codes_SRS_TQUEUE_01_040: [ TQUEUE_POP(T) shall call condition_function with condition_function_context and a pointer to the array entry value whose state was changed to POPPING. ] */ \
+                        should_pop = condition_function(condition_function_context, (T*)&tqueue->queue[index].value);                                                   \
+                    }                                                                                                                                               \
+                    else                                                                                                                                            \
+                    {                                                                                                                                               \
+                        /* Codes_SRS_TQUEUE_01_042: [ Otherwise, shall proceed with the pop. ]*/                                                                    \
+                        should_pop = true;                                                                                                                          \
+                    }                                                                                                                                               \
+                    if (!should_pop)                                                                                                                                \
+                    {                                                                                                                                               \
+                        /* Codes_SRS_TQUEUE_01_041: [ If condition_function returns false, TQUEUE_POP(T) shall set the state to USED by using interlocked_exchange and return TQUEUE_POP_REJECTED. ]*/ \
+                        (void)interlocked_exchange((volatile_atomic int32_t*)&tqueue->queue[index].state, QUEUE_ENTRY_STATE_USED);                                  \
+                        result = TQUEUE_POP_REJECTED;                                                                                                               \
+                    }                                                                                                                                               \
+                    else                                                                                                                                            \
+                    {                                                                                                                                               \
+                        /* Codes_SRS_TQUEUE_01_031: [ TQUEUE_POP(T) shall replace the tail value with the tail value obtained earlier + 1 by using interlocked_exchange_64. ]*/ \
+                        if (interlocked_compare_exchange_64((volatile_atomic int64_t*)&tqueue->tail, current_tail + 1, current_tail) != current_tail)               \
+                        {                                                                                                                                           \
+                            /* Codes_SRS_TQUEUE_01_044: [ If incrementing the tail by using interlocked_compare_exchange_64 does not succeed, TQUEUE_POP(T) shall revert the state of the array entry to USED and retry. ]*/ \
+                            (void)interlocked_exchange((volatile_atomic int32_t*)&tqueue->queue[index].state, QUEUE_ENTRY_STATE_USED);                              \
+                            continue;                                                                                                                               \
+                        }                                                                                                                                           \
+                        else                                                                                                                                        \
+                        {                                                                                                                                           \
+                            if (tqueue->pop_cb_function == NULL)                                                                                                    \
+                            {                                                                                                                                       \
+                                /* Codes_SRS_TQUEUE_01_032: [ If a pop_cb_function was not specified in TQUEUE_CREATE(T): ]*/                                       \
+                                /* Codes_SRS_TQUEUE_01_033: [ TQUEUE_POP(T) shall copy array entry value whose state was changed to POPPING to item. ]*/            \
+                                (void)memcpy((void*)item, (void*)(T*)&tqueue->queue[index].value, sizeof(T));                                                                    \
+                            }                                                                                                                                       \
+                            else                                                                                                                                    \
+                            {                                                                                                                                       \
+                                /* Codes_SRS_TQUEUE_01_037: [ If a pop_cb_function was specified in TQUEUE_CREATE(T): ]*/                                           \
+                                /* Codes_SRS_TQUEUE_01_038: [ TQUEUE_POP(T) shall call pop_cb_function with pop_cb_function_context as context, the array entry value whose state was changed to POPPING to item as pop_src and item as pop_dst. ]*/ \
+                                tqueue->pop_cb_function(pop_cb_function_context, item, (T*)&tqueue->queue[index].value);                                            \
+                            }                                                                                                                                       \
+                            /* Codes_SRS_TQUEUE_01_034: [ TQUEUE_POP(T) shall set the state to NOT_USED by using interlocked_exchange, succeed and return TQUEUE_POP_OK. ]*/ \
+                            (void)interlocked_exchange((volatile_atomic int32_t*)&tqueue->queue[index].state, QUEUE_ENTRY_STATE_NOT_USED);                          \
+                            result = TQUEUE_POP_OK;                                                                                                                 \
+                        }                                                                                                                                           \
+                    }                                                                                                                                               \
+                    break;                                                                                                                                          \
+                }                                                                                                                                                   \
+            }                                                                                                                                                       \
+        } while (1);                                                                                                                                                \
+    }                                                                                                                                                               \
+    return result;                                                                                                                                                  \
+}                                                                                                                                                                   \
+
+/*macro to be used in headers*/                                                                                                     \
+#define TQUEUE_LL_TYPE_DECLARE(C, T, ...)                                                                                           \
+    /*hint: have TQUEUE_DEFINE_STRUCT_TYPE(T) before TQUEUE_LL_TYPE_DECLARE*/                                                       \
+    THANDLE_LL_TYPE_DECLARE(TQUEUE_TYPEDEF_NAME(C), TQUEUE_TYPEDEF_NAME(T))                                                         \
+    TQUEUE_LL_CREATE_DECLARE(C, T)                                                                                                  \
+    TQUEUE_LL_PUSH_DECLARE(C, T)                                                                                                    \
+    TQUEUE_LL_POP_DECLARE(C, T)                                                                                                     \
+
+/*macro to be used in .c*/                                                                                                          \
+#define TQUEUE_LL_TYPE_DEFINE(C, T, ...)                                                                                            \
+    /*hint: have THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(T)) before TQUEUE_LL_TYPE_DEFINE*/                                         \
+    TQUEUE_LL_FREE_DEFINE(C, T)                                                                                                     \
+    TQUEUE_LL_CREATE_DEFINE(C, T)                                                                                                   \
+    TQUEUE_LL_PUSH_DEFINE(C, T)                                                                                                     \
+    TQUEUE_LL_POP_DEFINE(C, T)                                                                                                      \
 
 #endif  /*TQUEUE_LL_H*/

--- a/src/tqueue.c
+++ b/src/tqueue.c
@@ -7,9 +7,6 @@
 
 #include "c_logging/logger.h"
 
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-
 #include "clds/tqueue.h"
 
 MU_DEFINE_ENUM_STRINGS(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_RESULT_VALUES);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ if(${run_unittests})
     build_test_folder(clds_sorted_list_ut)
     build_test_folder(clds_hash_table_ut)
     build_test_folder(mpsc_lock_free_queue_ut)
+    build_test_folder(tqueue_ut)
 if(WIN32)
         # this test has a problem on Linux with the lack of srw_lock_ll reals
         # https://msazure.visualstudio.com/One/_backlogs/backlog/Azure%20Messaging%20Store/Backlog%20items/?workitem=25563889
@@ -37,6 +38,7 @@ endif()
     build_test_folder(clds_sorted_list_int)
     build_test_folder(mpsc_lock_free_queue_int)
     build_test_folder(tcall_dispatcher_int)
+    build_test_folder(tqueue_int)
 endif()
 
 #perf tests

--- a/tests/tcall_dispatcher_int/tcall_dispatcher_int.c
+++ b/tests/tcall_dispatcher_int/tcall_dispatcher_int.c
@@ -18,7 +18,7 @@
 #include "clds/tcall_dispatcher.h"
 #include "tcall_dispatcher_foo.h"
 
-// TCALL_DISPATCHER_(FOO) is used for most int tests
+// TCALL_DISPATCHER(FOO) is used for most int tests
 // It is declared and defined in its own .h/.c files in order to emulate usage in the wilderness
 
 static void test_target(void* context, int32_t x)

--- a/tests/tqueue_int/CMakeLists.txt
+++ b/tests/tqueue_int/CMakeLists.txt
@@ -15,4 +15,4 @@ set(${theseTestsName}_h_files
 tqueue_foo.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds c_pal c_pal_reals c_util c_util_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds c_pal c_util)

--- a/tests/tqueue_int/CMakeLists.txt
+++ b/tests/tqueue_int/CMakeLists.txt
@@ -1,0 +1,18 @@
+#Copyright (c) Microsoft. All rights reserved.
+
+set(theseTestsName tqueue_int)
+
+set(${theseTestsName}_test_files
+${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+tqueue_foo.c
+)
+
+set(${theseTestsName}_h_files
+../../inc/clds/tqueue.h
+tqueue_foo.h
+)
+
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds c_pal c_pal_reals c_util c_util_reals)

--- a/tests/tqueue_int/tqueue_foo.c
+++ b/tests/tqueue_int/tqueue_foo.c
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdlib.h>
+#include <stdint.h>
 
-#include "macro_utils/macro_utils.h"
-
-#include "c_logging/logger.h"
+#include "c_pal/thandle.h"
 
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"
 
 #include "clds/tqueue.h"
 
-MU_DEFINE_ENUM_STRINGS(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_RESULT_VALUES);
-MU_DEFINE_ENUM_STRINGS(TQUEUE_POP_RESULT, TQUEUE_POP_RESULT_VALUES);
+#include "tqueue_foo.h"
+
+// This is the queue used for most of the tests
+THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(FOO));
+TQUEUE_TYPE_DEFINE(FOO);

--- a/tests/tqueue_int/tqueue_foo.h
+++ b/tests/tqueue_int/tqueue_foo.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#ifndef TQUEUE_FOO_H
+#define TQUEUE_FOO_H
+
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+#include "c_pal/thandle.h"
+
+#include "clds/tqueue.h"
+
+typedef struct FOO_TAG
+{
+    int64_t x;
+} FOO;
+
+// This is the call dispatcher used for most of the tests
+TQUEUE_DEFINE_STRUCT_TYPE(FOO);
+THANDLE_TYPE_DECLARE(TQUEUE_TYPEDEF_NAME(FOO))
+TQUEUE_TYPE_DECLARE(FOO);
+
+#endif // TQUEUE_FOO_H

--- a/tests/tqueue_int/tqueue_int.c
+++ b/tests/tqueue_int/tqueue_int.c
@@ -1,0 +1,547 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <inttypes.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#include "c_pal/interlocked.h"
+#include "c_pal/thandle.h"
+#include "c_pal/threadapi.h"
+#include "c_pal/timer.h"
+
+#include "clds/tqueue.h"
+#include "tqueue_foo.h"
+
+// TQUEUE(FOO) is used for most int tests
+// It is declared and defined in its own .h/.c files in order to emulate usage in the wilderness
+
+// A queue with THANDLEs!
+typedef struct TEST_THANDLE_TAG
+{
+    int64_t a_value;
+} TEST_THANDLE;
+
+THANDLE_TYPE_DECLARE(TEST_THANDLE);
+THANDLE_TYPE_DEFINE(TEST_THANDLE);
+
+TQUEUE_DEFINE_STRUCT_TYPE(THANDLE(TEST_THANDLE));
+THANDLE_TYPE_DECLARE(TQUEUE_TYPEDEF_NAME(THANDLE(TEST_THANDLE)))
+TQUEUE_TYPE_DECLARE(THANDLE(TEST_THANDLE));
+
+THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(THANDLE(TEST_THANDLE)))
+TQUEUE_TYPE_DEFINE(THANDLE(TEST_THANDLE));
+
+#define XTEST_FUNCTION(A) void A(void)
+
+TEST_DEFINE_ENUM_TYPE(THREADAPI_RESULT, THREADAPI_RESULT_VALUES);
+TEST_DEFINE_ENUM_TYPE(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_RESULT_VALUES);
+TEST_DEFINE_ENUM_TYPE(TQUEUE_POP_RESULT, TQUEUE_POP_RESULT_VALUES);
+
+BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
+
+TEST_SUITE_INITIALIZE(suite_init)
+{
+}
+
+TEST_SUITE_CLEANUP(suite_cleanup)
+{
+}
+
+TEST_FUNCTION_INITIALIZE(method_init)
+{
+}
+
+TEST_FUNCTION_CLEANUP(method_cleanup)
+{
+}
+
+TEST_FUNCTION(TQUEUE_CREATE_with_NULL_callbacks_succeds)
+{
+    // arrange
+
+    // act
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_IS_NOT_NULL(queue);
+
+    // clean
+    TQUEUE_ASSIGN(FOO)(&queue, NULL);
+}
+
+TEST_FUNCTION(TQUEUE_PUSH_succeeds)
+{
+    // arrange
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    ASSERT_IS_NOT_NULL(queue);
+    FOO foo_1 = { 42 };
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(FOO)(queue, &foo_1, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result);
+
+    // clean
+    TQUEUE_ASSIGN(FOO)(&queue, NULL);
+}
+
+TEST_FUNCTION(TQUEUE_POP_succeeds)
+{
+    // arrange
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    ASSERT_IS_NOT_NULL(queue);
+    FOO foo_1 = { 42 };
+    FOO foo_1_popped;
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, TQUEUE_PUSH(FOO)(queue, &foo_1, NULL));
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(FOO)(queue, &foo_1_popped, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result);
+    ASSERT_ARE_EQUAL(int32_t, foo_1.x, foo_1_popped.x);
+
+    // clean
+    TQUEUE_ASSIGN(FOO)(&queue, NULL);
+}
+
+static bool pop_condition_function_42(void* context, const FOO* foo)
+{
+    (void)context;
+    return (foo->x == 42) ? true : false;
+}
+
+static bool pop_condition_function_43(void* context, const FOO* foo)
+{
+    (void)context;
+    return (foo->x == 43) ? true : false;
+}
+
+TEST_FUNCTION(TQUEUE_POP_IF_succeeds)
+{
+    // arrange
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    ASSERT_IS_NOT_NULL(queue);
+    FOO foo_1 = { 42 };
+    FOO foo_1_popped;
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, TQUEUE_PUSH(FOO)(queue, &foo_1, NULL));
+
+    // act
+    // assert
+    foo_1_popped.x = 45;
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_REJECTED, TQUEUE_POP(FOO)(queue, &foo_1_popped, NULL, pop_condition_function_43, NULL));
+    ASSERT_ARE_NOT_EQUAL(int32_t, foo_1.x, foo_1_popped.x);
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, TQUEUE_POP(FOO)(queue, &foo_1_popped, NULL, pop_condition_function_42, NULL));
+    ASSERT_ARE_EQUAL(int32_t, foo_1.x, foo_1_popped.x);
+
+    // clean
+    TQUEUE_ASSIGN(FOO)(&queue, NULL);
+}
+
+typedef struct TQUEUE_CHAOS_TEST_CONTEXT_TAG
+{
+    TQUEUE(FOO) queue;
+    volatile_atomic int64_t next_push_number;
+    volatile_atomic int64_t succesful_push_count;
+    volatile_atomic int64_t succesful_pop_count;
+} TQUEUE_CHAOS_TEST_CONTEXT;
+
+#define TQUEUE_ACTION_TYPE_VALUES \
+    TQUEUE_ACTION_TYPE_PUSH, \
+    TQUEUE_ACTION_TYPE_POP \
+
+MU_DEFINE_ENUM_WITHOUT_INVALID(TQUEUE_ACTION_TYPE, TQUEUE_ACTION_TYPE_VALUES);
+MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(TQUEUE_ACTION_TYPE, TQUEUE_ACTION_TYPE_VALUES);
+
+static volatile_atomic int32_t terminate_test;
+
+static int tqueue_chaos_thread_func(void* arg)
+{
+    TQUEUE_CHAOS_TEST_CONTEXT* test_context = arg;
+
+    while (interlocked_add(&terminate_test, 0) == 0)
+    {
+        TQUEUE_ACTION_TYPE action_type = (TQUEUE_ACTION_TYPE)(rand() * ((MU_COUNT_ARG(TQUEUE_ACTION_TYPE_VALUES))) / (RAND_MAX + 1));
+
+        switch (action_type)
+        {
+        default:
+            ASSERT_FAIL("Unexpected action type %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_ACTION_TYPE, action_type));
+            break;
+
+        case TQUEUE_ACTION_TYPE_PUSH:
+        {
+            int64_t next_push_number = interlocked_increment_64(&test_context->next_push_number);
+            FOO item = { .x = next_push_number };
+            TQUEUE_PUSH_RESULT push_result = TQUEUE_PUSH(FOO)(test_context->queue, &item, NULL);
+            ASSERT_IS_TRUE((push_result == TQUEUE_PUSH_OK) || (push_result == TQUEUE_PUSH_QUEUE_FULL), "TQUEUE_PUSH(FOO) failed with %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_PUSH_RESULT, push_result));
+            if (push_result == TQUEUE_PUSH_OK)
+            {
+                (void)interlocked_increment_64(&test_context->succesful_push_count);
+            }
+            break;
+        }
+        case TQUEUE_ACTION_TYPE_POP:
+        {
+            FOO item = { .x = -1 };
+            TQUEUE_POP_RESULT pop_result = TQUEUE_POP(FOO)(test_context->queue, &item, NULL, NULL, NULL);
+            ASSERT_IS_TRUE((pop_result == TQUEUE_POP_OK) || (pop_result == TQUEUE_POP_QUEUE_EMPTY), "TQUEUE_POP(FOO) failed with %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_POP_RESULT, pop_result));
+            if (pop_result == TQUEUE_POP_OK)
+            {
+                (void)interlocked_increment_64(&test_context->succesful_pop_count);
+            }
+            break;
+        }
+        }
+
+#ifdef USE_VALGRIND
+        // yield
+        ThreadAPI_Sleep(0);
+#endif
+    }
+
+    return 0;
+}
+
+#define TEST_CHECK_PERIOD 500 // ms
+
+#define N_THREADS 16
+
+#ifdef USE_VALGRIND
+#define CHAOS_TEST_RUNTIME 5000 // ms
+#else // USE_VALGRIND
+#define CHAOS_TEST_RUNTIME 1000 // ms
+#endif
+
+// This test is rather chaotic and has a number of threads performing random actions on the queue
+TEST_FUNCTION(TQUEUE_chaos_knight_test)
+{
+    // arrange
+    TQUEUE_CHAOS_TEST_CONTEXT test_context;
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    ASSERT_IS_NOT_NULL(queue);
+    TQUEUE_INITIALIZE_MOVE(FOO)(&test_context.queue, &queue);
+
+    (void)interlocked_exchange_64(&test_context.next_push_number, 1);
+
+    // count how many successful pushes and pops we have
+    (void)interlocked_exchange_64(&test_context.succesful_push_count, 0);
+    (void)interlocked_exchange_64(&test_context.succesful_pop_count, 0);
+    (void)interlocked_exchange(&terminate_test, 0);
+
+    // act
+    // assert
+    THREAD_HANDLE thread_handles[N_THREADS];
+    for (uint32_t i = 0; i < N_THREADS; i++)
+    {
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&thread_handles[i], tqueue_chaos_thread_func, &test_context));
+    }
+
+    double start_time = timer_global_get_elapsed_ms();
+    double current_time = start_time;
+    do
+    {
+        // get how many pushes and pops at the beginning of the time slice
+        int64_t last_succesful_push_count = interlocked_add_64(&test_context.succesful_push_count, 0);
+        int64_t last_succesful_pop_count = interlocked_add_64(&test_context.succesful_pop_count, 0);
+
+        ThreadAPI_Sleep(TEST_CHECK_PERIOD);
+
+        // get how many pushes and pops at the end of the time slice
+        int64_t current_succesful_push_count = interlocked_add_64(&test_context.succesful_push_count, 0);
+        int64_t current_succesful_pop_count = interlocked_add_64(&test_context.succesful_pop_count, 0);
+
+        // make sure we had at least one succesful push and one pop (not stuck)
+        ASSERT_IS_TRUE(current_succesful_push_count > last_succesful_push_count);
+        ASSERT_IS_TRUE(current_succesful_pop_count > last_succesful_pop_count);
+
+        current_time = timer_global_get_elapsed_ms();
+
+        LogInfo("%.02f seconds elapsed, successful push count=%" PRId64 ", successful pop count=%" PRId64 "",
+            (current_time - start_time) / 1000, current_succesful_push_count, current_succesful_pop_count);
+    } while (current_time - start_time < CHAOS_TEST_RUNTIME);
+
+    ThreadAPI_Sleep(CHAOS_TEST_RUNTIME);
+
+    // terminate test
+    (void)interlocked_exchange(&terminate_test, 1);
+
+    for (uint32_t i = 0; i < N_THREADS; i++)
+    {
+        int dont_care;
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(thread_handles[i], &dont_care));
+    }
+
+    // clean
+    TQUEUE_ASSIGN(FOO)(&test_context.queue, NULL);
+}
+
+typedef struct ONE_PUSHER_ONE_POPPER_TEST_CONTEXT_TAG
+{
+    TQUEUE(FOO) queue;
+    volatile_atomic int64_t next_push_number;
+    volatile_atomic int64_t next_expected_pop_number;
+} ONE_PUSHER_ONE_POPPER_TEST_CONTEXT;
+
+#ifdef USE_VALGRIND
+#define ONE_PUSHE_ONE_POPPER_TEST_RUNTIME 5000 // ms
+#else // USE_VALGRIND
+#define ONE_PUSHE_ONE_POPPER_TEST_RUNTIME 1000 // ms
+#endif
+
+static int pusher_thread_func(void* arg)
+{
+    ONE_PUSHER_ONE_POPPER_TEST_CONTEXT* test_context = arg;
+
+    while (interlocked_add(&terminate_test, 0) == 0)
+    {
+        int64_t next_push_number = interlocked_increment_64(&test_context->next_push_number) - 1;
+        FOO item = { .x = next_push_number };
+        TQUEUE_PUSH_RESULT push_result = TQUEUE_PUSH(FOO)(test_context->queue, &item, NULL);
+        ASSERT_IS_TRUE((push_result == TQUEUE_PUSH_OK) || (push_result == TQUEUE_PUSH_QUEUE_FULL), "TQUEUE_PUSH(FOO) failed with %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_PUSH_RESULT, push_result));
+        if (push_result == TQUEUE_PUSH_QUEUE_FULL)
+        {
+            (void)interlocked_decrement_64(&test_context->next_push_number);
+        }
+
+#ifdef USE_VALGRIND
+        // yield
+        ThreadAPI_Sleep(0);
+#endif
+    }
+
+    return 0;
+}
+
+static int popper_thread_func(void* arg)
+{
+    ONE_PUSHER_ONE_POPPER_TEST_CONTEXT* test_context = arg;
+
+    while (interlocked_add(&terminate_test, 0) == 0)
+    {
+        FOO item = { .x = -1 };
+        TQUEUE_POP_RESULT pop_result = TQUEUE_POP(FOO)(test_context->queue, &item, NULL, NULL, NULL);
+        ASSERT_IS_TRUE((pop_result == TQUEUE_POP_OK) || (pop_result == TQUEUE_POP_QUEUE_EMPTY), "TQUEUE_POP(FOO) failed with %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_POP_RESULT, pop_result));
+        if (pop_result == TQUEUE_POP_OK)
+        {
+            int64_t expected_pop_number = interlocked_increment_64(&test_context->next_expected_pop_number) - 1;
+            ASSERT_ARE_EQUAL(int, expected_pop_number, item.x);
+        }
+
+#ifdef USE_VALGRIND
+        // yield
+        ThreadAPI_Sleep(0);
+#endif
+    }
+
+    return 0;
+}
+
+// This test has one pusher and one popper and validates the fact that order is preserved in this case
+XTEST_FUNCTION(TQUEUE_test_with_1_pusher_and_1_popper)
+{
+    // arrange
+    ONE_PUSHER_ONE_POPPER_TEST_CONTEXT test_context;
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    ASSERT_IS_NOT_NULL(queue);
+    TQUEUE_INITIALIZE_MOVE(FOO)(&test_context.queue, &queue);
+
+    (void)interlocked_exchange_64(&test_context.next_push_number, 1);
+    (void)interlocked_exchange_64(&test_context.next_expected_pop_number, 1);
+    (void)interlocked_exchange(&terminate_test, 0);
+
+    THREAD_HANDLE pusher_thread;
+    THREAD_HANDLE popper_thread;
+
+    // act
+    ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&pusher_thread, pusher_thread_func, &test_context));
+    ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&popper_thread, popper_thread_func, &test_context));
+
+    double start_time = timer_global_get_elapsed_ms();
+    double current_time = start_time;
+    do
+    {
+        int64_t last_expected_pop_number = interlocked_add_64(&test_context.next_expected_pop_number, 0);
+
+        ThreadAPI_Sleep(TEST_CHECK_PERIOD);
+
+        int64_t current_expected_pop_number = interlocked_add_64(&test_context.next_expected_pop_number, 0);
+        ASSERT_IS_TRUE(current_expected_pop_number - last_expected_pop_number > 0);
+
+        LogInfo("%.02f seconds elapsed, current_expected_pop_number is %" PRId64 "",
+            (current_time - start_time) / 1000, current_expected_pop_number);
+
+        current_time = timer_global_get_elapsed_ms();
+    } while (current_time - start_time < ONE_PUSHE_ONE_POPPER_TEST_RUNTIME);
+
+    // terminate test
+    (void)interlocked_exchange(&terminate_test, 1);
+
+    {
+        int dont_care;
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(pusher_thread, &dont_care));
+    }
+
+    {
+        int dont_care;
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(popper_thread, &dont_care));
+    }
+
+    // assert
+
+    // clean
+    TQUEUE_ASSIGN(FOO)(&test_context.queue, NULL);
+}
+
+// This test is very similar to the one without the THANDLE
+// They could be generated with a macro, but then debugability would really be horrible
+typedef struct TQUEUE_CHAOS_TEST_THANDLE_CONTEXT_TAG
+{
+    TQUEUE(THANDLE(TEST_THANDLE)) queue;
+    volatile_atomic int64_t next_push_number;
+    volatile_atomic int64_t succesful_push_count;
+    volatile_atomic int64_t succesful_pop_count;
+} TQUEUE_CHAOS_TEST_THANDLE_CONTEXT;
+
+static int tqueue_chaos_thread_THANDLE_func(void* arg)
+{
+    TQUEUE_CHAOS_TEST_THANDLE_CONTEXT* test_context = arg;
+
+    while (interlocked_add(&terminate_test, 0) == 0)
+    {
+        TQUEUE_ACTION_TYPE action_type = (TQUEUE_ACTION_TYPE)(rand() * ((MU_COUNT_ARG(TQUEUE_ACTION_TYPE_VALUES))) / (RAND_MAX + 1));
+
+        switch (action_type)
+        {
+        default:
+            ASSERT_FAIL("Unexpected action type %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_ACTION_TYPE, action_type));
+            break;
+
+        case TQUEUE_ACTION_TYPE_PUSH:
+        {
+            int64_t next_push_number = interlocked_increment_64(&test_context->next_push_number);
+            TEST_THANDLE test_thandle = { .a_value = next_push_number };
+            THANDLE(TEST_THANDLE) item = THANDLE_CREATE_FROM_CONTENT(TEST_THANDLE)(&test_thandle, NULL, NULL);
+            TQUEUE_PUSH_RESULT push_result = TQUEUE_PUSH(THANDLE(TEST_THANDLE))(test_context->queue, &item, NULL);
+            ASSERT_IS_TRUE((push_result == TQUEUE_PUSH_OK) || (push_result == TQUEUE_PUSH_QUEUE_FULL), "TQUEUE_PUSH(THANDLE(TEST_THANDLE)) failed with %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_PUSH_RESULT, push_result));
+            if (push_result == TQUEUE_PUSH_OK)
+            {
+                (void)interlocked_increment_64(&test_context->succesful_push_count);
+            }
+            THANDLE_ASSIGN(TEST_THANDLE)(&item, NULL);
+            break;
+        }
+        case TQUEUE_ACTION_TYPE_POP:
+        {
+            THANDLE(TEST_THANDLE) item = NULL;
+            TQUEUE_POP_RESULT pop_result = TQUEUE_POP(THANDLE(TEST_THANDLE))(test_context->queue, &item, NULL, NULL, NULL);
+            ASSERT_IS_TRUE((pop_result == TQUEUE_POP_OK) || (pop_result == TQUEUE_POP_QUEUE_EMPTY), "TQUEUE_POP(THANDLE(TEST_THANDLE)) failed with %" PRI_MU_ENUM "", MU_ENUM_VALUE(TQUEUE_POP_RESULT, pop_result));
+            if (pop_result == TQUEUE_POP_OK)
+            {
+                (void)interlocked_increment_64(&test_context->succesful_pop_count);
+                THANDLE_ASSIGN(TEST_THANDLE)(&item, NULL);
+            }
+            break;
+        }
+        }
+
+#ifdef USE_VALGRIND
+        // yield
+        ThreadAPI_Sleep(0);
+#endif
+    }
+
+    return 0;
+}
+
+static void TEST_THANDLE_push(void* context, THANDLE(TEST_THANDLE)* push_dst, THANDLE(TEST_THANDLE)* push_src)
+{
+    (void)context;
+    THANDLE_INITIALIZE(TEST_THANDLE)(push_dst, *push_src);
+}
+
+static void TEST_THANDLE_pop(void* context, THANDLE(TEST_THANDLE)* pop_dst, THANDLE(TEST_THANDLE)* pop_src)
+{
+    (void)context;
+    THANDLE_MOVE(TEST_THANDLE)(pop_dst, pop_src);
+}
+
+static void TEST_THANDLE_dispose(void* context, THANDLE(TEST_THANDLE)* item)
+{
+    (void)context;
+    THANDLE_ASSIGN(TEST_THANDLE)(item, NULL);
+}
+
+// This test is rather chaotic and has a number of threads performing random actions on the queue
+// But on top it is exercising a queue of THANDLE elements!
+TEST_FUNCTION(TQUEUE_chaos_knight_test_with_THANDLE)
+{
+    // arrange
+    TQUEUE_CHAOS_TEST_THANDLE_CONTEXT test_context;
+    TQUEUE(THANDLE(TEST_THANDLE)) queue = TQUEUE_CREATE(THANDLE(TEST_THANDLE))(16, TEST_THANDLE_push, TEST_THANDLE_pop, TEST_THANDLE_dispose, NULL);
+    ASSERT_IS_NOT_NULL(queue);
+    TQUEUE_INITIALIZE_MOVE(THANDLE(TEST_THANDLE))(&test_context.queue, &queue);
+
+    (void)interlocked_exchange_64(&test_context.next_push_number, 1);
+
+    // count how many successful pushes and pops we have
+    (void)interlocked_exchange_64(&test_context.succesful_push_count, 0);
+    (void)interlocked_exchange_64(&test_context.succesful_pop_count, 0);
+    (void)interlocked_exchange(&terminate_test, 0);
+
+    // act
+    // assert
+    THREAD_HANDLE thread_handles[N_THREADS];
+    for (uint32_t i = 0; i < N_THREADS; i++)
+    {
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Create(&thread_handles[i], tqueue_chaos_thread_THANDLE_func, &test_context));
+    }
+
+    double start_time = timer_global_get_elapsed_ms();
+    double current_time = start_time;
+    do
+    {
+        // get how many pushes and pops at the beginning of the time slice
+        int64_t last_succesful_push_count = interlocked_add_64(&test_context.succesful_push_count, 0);
+        int64_t last_succesful_pop_count = interlocked_add_64(&test_context.succesful_pop_count, 0);
+
+        ThreadAPI_Sleep(TEST_CHECK_PERIOD);
+
+        // get how many pushes and pops at the end of the time slice
+        int64_t current_succesful_push_count = interlocked_add_64(&test_context.succesful_push_count, 0);
+        int64_t current_succesful_pop_count = interlocked_add_64(&test_context.succesful_pop_count, 0);
+
+        // make sure we had at least one succesful push and one pop (not stuck)
+        ASSERT_IS_TRUE(current_succesful_push_count > last_succesful_push_count);
+        ASSERT_IS_TRUE(current_succesful_pop_count > last_succesful_pop_count);
+
+        current_time = timer_global_get_elapsed_ms();
+
+        LogInfo("%.02f seconds elapsed, successful push count=%" PRId64 ", successful pop count=%" PRId64 "",
+            (current_time - start_time) / 1000, current_succesful_push_count, current_succesful_pop_count);
+    } while (current_time - start_time < CHAOS_TEST_RUNTIME);
+
+    ThreadAPI_Sleep(CHAOS_TEST_RUNTIME);
+
+    // terminate test
+    (void)interlocked_exchange(&terminate_test, 1);
+
+    for (uint32_t i = 0; i < N_THREADS; i++)
+    {
+        int dont_care;
+        ASSERT_ARE_EQUAL(THREADAPI_RESULT, THREADAPI_OK, ThreadAPI_Join(thread_handles[i], &dont_care));
+    }
+
+    // clean
+    TQUEUE_ASSIGN(THANDLE(TEST_THANDLE))(&test_context.queue, NULL);
+}
+
+END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)

--- a/tests/tqueue_int/tqueue_int.c
+++ b/tests/tqueue_int/tqueue_int.c
@@ -67,7 +67,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_NULL_callbacks_succeds)
     // arrange
 
     // act
-    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL);
 
     // assert
     ASSERT_IS_NOT_NULL(queue);
@@ -79,7 +79,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_NULL_callbacks_succeds)
 TEST_FUNCTION(TQUEUE_PUSH_succeeds)
 {
     // arrange
-    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL);
     ASSERT_IS_NOT_NULL(queue);
     FOO foo_1 = { 42 };
 
@@ -96,7 +96,7 @@ TEST_FUNCTION(TQUEUE_PUSH_succeeds)
 TEST_FUNCTION(TQUEUE_POP_succeeds)
 {
     // arrange
-    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL);
     ASSERT_IS_NOT_NULL(queue);
     FOO foo_1 = { 42 };
     FOO foo_1_popped;
@@ -128,7 +128,7 @@ static bool pop_condition_function_43(void* context, FOO* foo)
 TEST_FUNCTION(TQUEUE_POP_IF_succeeds)
 {
     // arrange
-    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL);
     ASSERT_IS_NOT_NULL(queue);
     FOO foo_1 = { 42 };
     FOO foo_1_popped;
@@ -226,7 +226,7 @@ TEST_FUNCTION(TQUEUE_chaos_knight_test)
 {
     // arrange
     TQUEUE_CHAOS_TEST_CONTEXT test_context;
-    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL);
     ASSERT_IS_NOT_NULL(queue);
     TQUEUE_INITIALIZE_MOVE(FOO)(&test_context.queue, &queue);
 
@@ -350,7 +350,7 @@ TEST_FUNCTION(TQUEUE_test_with_1_pusher_and_1_popper)
 {
     // arrange
     ONE_PUSHER_ONE_POPPER_TEST_CONTEXT test_context;
-    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL, NULL);
+    TQUEUE(FOO) queue = TQUEUE_CREATE(FOO)(16, NULL, NULL, NULL);
     ASSERT_IS_NOT_NULL(queue);
     TQUEUE_INITIALIZE_MOVE(FOO)(&test_context.queue, &queue);
 
@@ -490,16 +490,10 @@ static int tqueue_chaos_thread_THANDLE_func(void* arg)
     return 0;
 }
 
-static void TEST_THANDLE_push(void* context, THANDLE(TEST_THANDLE)* push_dst, THANDLE(TEST_THANDLE)* push_src)
+static void TEST_THANDLE_copy_item(void* context, THANDLE(TEST_THANDLE)* dst, THANDLE(TEST_THANDLE)* src)
 {
     (void)context;
-    THANDLE_INITIALIZE(TEST_THANDLE)(push_dst, *push_src);
-}
-
-static void TEST_THANDLE_pop(void* context, THANDLE(TEST_THANDLE)* pop_dst, THANDLE(TEST_THANDLE)* pop_src)
-{
-    (void)context;
-    THANDLE_MOVE(TEST_THANDLE)(pop_dst, pop_src);
+    THANDLE_INITIALIZE(TEST_THANDLE)(dst, *src);
 }
 
 static void TEST_THANDLE_dispose(void* context, THANDLE(TEST_THANDLE)* item)
@@ -515,7 +509,7 @@ TEST_FUNCTION(TQUEUE_chaos_knight_test_with_THANDLE)
 {
     // arrange
     TQUEUE_CHAOS_TEST_THANDLE_CONTEXT test_context;
-    TQUEUE(THANDLE(TEST_THANDLE)) queue = TQUEUE_CREATE(THANDLE(TEST_THANDLE))(16, TEST_THANDLE_push, TEST_THANDLE_pop, TEST_THANDLE_dispose, NULL);
+    TQUEUE(THANDLE(TEST_THANDLE)) queue = TQUEUE_CREATE(THANDLE(TEST_THANDLE))(16, TEST_THANDLE_copy_item, TEST_THANDLE_dispose, NULL);
     ASSERT_IS_NOT_NULL(queue);
     TQUEUE_INITIALIZE_MOVE(THANDLE(TEST_THANDLE))(&test_context.queue, &queue);
 

--- a/tests/tqueue_int/tqueue_int.c
+++ b/tests/tqueue_int/tqueue_int.c
@@ -113,13 +113,13 @@ TEST_FUNCTION(TQUEUE_POP_succeeds)
     TQUEUE_ASSIGN(FOO)(&queue, NULL);
 }
 
-static bool pop_condition_function_42(void* context, const FOO* foo)
+static bool pop_condition_function_42(void* context, FOO* foo)
 {
     (void)context;
     return (foo->x == 42) ? true : false;
 }
 
-static bool pop_condition_function_43(void* context, const FOO* foo)
+static bool pop_condition_function_43(void* context, FOO* foo)
 {
     (void)context;
     return (foo->x == 43) ? true : false;

--- a/tests/tqueue_int/tqueue_int.c
+++ b/tests/tqueue_int/tqueue_int.c
@@ -415,7 +415,7 @@ static bool TEST_THANDLE_should_pop(void* context, THANDLE(TEST_THANDLE)* item)
 {
     (void)context;
     (void)item;
-    int should_pop = (rand() * 2 / (RAND_MAX + 1));
+    int should_pop = ((uint32_t)rand() * 2 / ((uint32_t)RAND_MAX + 1));
     return (should_pop != 0);
 }
 

--- a/tests/tqueue_int/tqueue_int.c
+++ b/tests/tqueue_int/tqueue_int.c
@@ -169,7 +169,7 @@ static int tqueue_chaos_thread_func(void* arg)
 
     while (interlocked_add(&terminate_test, 0) == 0)
     {
-        TQUEUE_ACTION_TYPE action_type = (TQUEUE_ACTION_TYPE)(rand() * ((MU_COUNT_ARG(TQUEUE_ACTION_TYPE_VALUES))) / (RAND_MAX + 1));
+        TQUEUE_ACTION_TYPE action_type = (TQUEUE_ACTION_TYPE)((uint32_t)rand() * ((MU_COUNT_ARG(TQUEUE_ACTION_TYPE_VALUES))) / ((uint32_t)RAND_MAX + 1));
 
         switch (action_type)
         {
@@ -346,7 +346,7 @@ static int popper_thread_func(void* arg)
 }
 
 // This test has one pusher and one popper and validates the fact that order is preserved in this case
-XTEST_FUNCTION(TQUEUE_test_with_1_pusher_and_1_popper)
+TEST_FUNCTION(TQUEUE_test_with_1_pusher_and_1_popper)
 {
     // arrange
     ONE_PUSHER_ONE_POPPER_TEST_CONTEXT test_context;
@@ -433,7 +433,7 @@ static int tqueue_chaos_thread_THANDLE_func(void* arg)
 
     while (interlocked_add(&terminate_test, 0) == 0)
     {
-        TQUEUE_ACTION_TYPE_THANDLE_TEST action_type = (TQUEUE_ACTION_TYPE_THANDLE_TEST)(rand() * ((MU_COUNT_ARG(TQUEUE_ACTION_TYPE_THANDLE_TEST_VALUES))) / (RAND_MAX + 1));
+        TQUEUE_ACTION_TYPE_THANDLE_TEST action_type = (TQUEUE_ACTION_TYPE_THANDLE_TEST)((uint32_t)rand() * ((MU_COUNT_ARG(TQUEUE_ACTION_TYPE_THANDLE_TEST_VALUES))) / ((uint32_t)RAND_MAX + 1));
 
         switch (action_type)
         {

--- a/tests/tqueue_ut/CMakeLists.txt
+++ b/tests/tqueue_ut/CMakeLists.txt
@@ -1,0 +1,16 @@
+#Copyright (c) Microsoft. All rights reserved.
+
+set(theseTestsName tqueue_ut)
+
+set(${theseTestsName}_test_files
+${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+)
+
+set(${theseTestsName}_h_files
+../../inc/clds/tqueue.h
+)
+
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds c_pal c_pal_reals c_util c_util_reals)

--- a/tests/tqueue_ut/tqueue_ut.c
+++ b/tests/tqueue_ut/tqueue_ut.c
@@ -46,11 +46,11 @@ TQUEUE_TYPE_DECLARE(int32_t);
 THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(int32_t))
 TQUEUE_TYPE_DEFINE(int32_t);
 
-MOCK_FUNCTION_WITH_CODE(, void, test_push_cb_1, void*, context, int32_t*, push_dst, const int32_t*, push_src)
+MOCK_FUNCTION_WITH_CODE(, void, test_push_cb, void*, context, int32_t*, push_dst, const int32_t*, push_src)
     *push_dst = *push_src;
 MOCK_FUNCTION_END();
 
-MOCK_FUNCTION_WITH_CODE(, void, test_pop_cb_1, void*, context, int32_t*, pop_dst, const int32_t*, pop_src)
+MOCK_FUNCTION_WITH_CODE(, void, test_pop_cb, void*, context, int32_t*, pop_dst, const int32_t*, pop_src)
     *pop_dst = *pop_src;
 MOCK_FUNCTION_END();
 
@@ -112,7 +112,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_0_queue_size_fails)
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(0, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(0, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
@@ -125,7 +125,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_only_push_cb_being_NULL_fails)
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
@@ -138,7 +138,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_only_pop_cb_being_NULL_fails)
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, NULL, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, NULL, test_dispose_item, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
@@ -151,7 +151,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_only_dispose_item_being_NULL_fails)
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, test_pop_cb_1, NULL, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, test_pop_cb, NULL, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
@@ -177,7 +177,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_push_cb_and_dispose_item_NULL_fails)
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb_1, NULL, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb, NULL, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
@@ -201,7 +201,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_all_functions_non_NULL_succeeds)
     }
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     // assert
     ASSERT_IS_NOT_NULL(queue);
@@ -265,7 +265,7 @@ TEST_FUNCTION(when_underlying_calls_fail_TQUEUE_CREATE_also_fails)
             umock_c_negative_tests_fail_call(i);
 
             // act
-            TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+            TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
             // assert
             ASSERT_IS_NULL(queue, "test failed for call %" PRIu32 "", i);
@@ -315,7 +315,7 @@ TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_NULL_dispose_item_returns)
 TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_empty_queue_does_not_call_dispose_item)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -364,7 +364,7 @@ static int32_t test_queue_pop_rejected(TQUEUE(int32_t) queue)
 TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_1_item_calls_dispose_item_once)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
@@ -386,7 +386,7 @@ TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_1_item_calls_d
 TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_2_items_calls_dispose_item_2_times)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
     test_queue_push(queue, 42);
 
@@ -424,7 +424,7 @@ TEST_FUNCTION(TQUEUE_PUSH_with_NULL_queue_fails)
 TEST_FUNCTION(TQUEUE_PUSH_with_NULL_item_fails)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     // act
     TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, NULL, (void*)0x4243);
@@ -609,13 +609,13 @@ TEST_FUNCTION(TQUEUE_PUSH_with_push_cb_function_calls_the_cb_function)
 {
     // arrange
     int32_t item = 42;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
-    STRICT_EXPECTED_CALL(test_push_cb_1((void*)0x4243, IGNORED_ARG, &item)); // entry state
+    STRICT_EXPECTED_CALL(test_push_cb((void*)0x4243, IGNORED_ARG, &item)); // entry state
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
 
     // act
@@ -635,20 +635,20 @@ TEST_FUNCTION(TQUEUE_PUSH_with_push_cb_function_calls_the_cb_function_2_items)
     // arrange
     int32_t item_1 = 42;
     int32_t item_2 = 43;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
-    STRICT_EXPECTED_CALL(test_push_cb_1((void*)0x4243, IGNORED_ARG, &item_1)); // entry state
+    STRICT_EXPECTED_CALL(test_push_cb((void*)0x4243, IGNORED_ARG, &item_1)); // entry state
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // head change
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
-    STRICT_EXPECTED_CALL(test_push_cb_1((void*)0x4244, IGNORED_ARG, &item_2)); // entry state
+    STRICT_EXPECTED_CALL(test_push_cb((void*)0x4244, IGNORED_ARG, &item_2)); // entry state
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
 
     // act
@@ -684,7 +684,7 @@ TEST_FUNCTION(TQUEUE_POP_with_NULL_tqueue_fails)
 TEST_FUNCTION(TQUEUE_POP_with_NULL_item_fails)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
 
     // act
     TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, NULL, (void*)0x4243, test_condition_function_true, (void*)0x4244);
@@ -896,14 +896,14 @@ TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_succeeds)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4243, &item, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4243, &item, IGNORED_ARG)); // tail
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     // act
@@ -925,7 +925,7 @@ TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_twice_succeeds)
     // arrange
     int32_t item_1 = 45;
     int32_t item_2 = 46;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
     test_queue_push(queue, 43);
 
@@ -933,14 +933,14 @@ TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_twice_succeeds)
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4243, &item_1, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4243, &item_1, IGNORED_ARG)); // tail
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4244, &item_2, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4244, &item_2, IGNORED_ARG)); // tail
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     // act
@@ -1048,7 +1048,7 @@ TEST_FUNCTION(when_switching_the_tail_does_not_succeed_TQUEUE_POP_retries)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -1063,7 +1063,7 @@ TEST_FUNCTION(when_switching_the_tail_does_not_succeed_TQUEUE_POP_retries)
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4243, &item, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4243, &item, IGNORED_ARG)); // tail
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     // act

--- a/tests/tqueue_ut/tqueue_ut.c
+++ b/tests/tqueue_ut/tqueue_ut.c
@@ -46,21 +46,21 @@ TQUEUE_TYPE_DECLARE(int32_t);
 THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(int32_t))
 TQUEUE_TYPE_DEFINE(int32_t);
 
-MOCK_FUNCTION_WITH_CODE(, void, test_push_cb, void*, context, int32_t*, push_dst, const int32_t*, push_src)
+MOCK_FUNCTION_WITH_CODE(, void, test_push_cb, void*, context, int32_t*, push_dst, int32_t*, push_src)
     *push_dst = *push_src;
 MOCK_FUNCTION_END();
 
-MOCK_FUNCTION_WITH_CODE(, void, test_pop_cb, void*, context, int32_t*, pop_dst, const int32_t*, pop_src)
+MOCK_FUNCTION_WITH_CODE(, void, test_pop_cb, void*, context, int32_t*, pop_dst, int32_t*, pop_src)
     *pop_dst = *pop_src;
 MOCK_FUNCTION_END();
 
-MOCK_FUNCTION_WITH_CODE(, void, test_dispose_item, void*, context, const int32_t*, item)
+MOCK_FUNCTION_WITH_CODE(, void, test_dispose_item, void*, context, int32_t*, item)
 MOCK_FUNCTION_END();
 
-MOCK_FUNCTION_WITH_CODE(, bool, test_condition_function_true, void*, context, const int32_t*, item)
+MOCK_FUNCTION_WITH_CODE(, bool, test_condition_function_true, void*, context, int32_t*, item)
 MOCK_FUNCTION_END(true);
 
-MOCK_FUNCTION_WITH_CODE(, bool, test_condition_function_false, void*, context, const int32_t*, item)
+MOCK_FUNCTION_WITH_CODE(, bool, test_condition_function_false, void*, context, int32_t*, item)
 MOCK_FUNCTION_END(false);
 
 static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)

--- a/tests/tqueue_ut/tqueue_ut.c
+++ b/tests/tqueue_ut/tqueue_ut.c
@@ -1,0 +1,1081 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <inttypes.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umock_c_negative_tests.h"
+#include "umock_c/umocktypes_bool.h"
+#include "umock_c/umocktypes_charptr.h"
+#include "umock_c/umocktypes_stdint.h"
+
+#define ENABLE_MOCKS
+#include "c_pal/interlocked.h"
+
+#undef ENABLE_MOCKS
+
+#include "c_pal/thandle.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+#include "c_pal/interlocked.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+#include "real_interlocked.h"
+
+#include "clds/tqueue.h"
+
+MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
+
+TEST_DEFINE_ENUM_TYPE(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_RESULT_VALUES)
+TEST_DEFINE_ENUM_TYPE(TQUEUE_POP_RESULT, TQUEUE_POP_RESULT_VALUES)
+
+// This is the call dispatcher used for most tests
+TQUEUE_DEFINE_STRUCT_TYPE(int32_t);
+THANDLE_TYPE_DECLARE(TQUEUE_TYPEDEF_NAME(int32_t))
+TQUEUE_TYPE_DECLARE(int32_t);
+THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(int32_t))
+TQUEUE_TYPE_DEFINE(int32_t);
+
+MOCK_FUNCTION_WITH_CODE(, void, test_push_cb_1, void*, context, int32_t*, push_dst, const int32_t*, push_src)
+    *push_dst = *push_src;
+MOCK_FUNCTION_END();
+
+MOCK_FUNCTION_WITH_CODE(, void, test_pop_cb_1, void*, context, int32_t*, pop_dst, const int32_t*, pop_src)
+    *pop_dst = *pop_src;
+MOCK_FUNCTION_END();
+
+MOCK_FUNCTION_WITH_CODE(, void, test_dispose_item, void*, context, const int32_t*, item)
+MOCK_FUNCTION_END();
+
+MOCK_FUNCTION_WITH_CODE(, bool, test_condition_function_true, void*, context, const int32_t*, item)
+MOCK_FUNCTION_END(true);
+
+MOCK_FUNCTION_WITH_CODE(, bool, test_condition_function_false, void*, context, const int32_t*, item)
+MOCK_FUNCTION_END(false);
+
+static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
+{
+    ASSERT_FAIL("umock_c reported error :%" PRI_MU_ENUM "", MU_ENUM_VALUE(UMOCK_C_ERROR_CODE, error_code));
+}
+
+BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
+
+TEST_SUITE_INITIALIZE(suite_init)
+{
+    ASSERT_ARE_EQUAL(int, 0, real_gballoc_hl_init(NULL, NULL));
+
+    ASSERT_ARE_EQUAL(int, 0, umock_c_init(on_umock_c_error));
+    ASSERT_ARE_EQUAL(int, 0, umocktypes_bool_register_types(), "umocktypes_bool_register_types failed");
+    ASSERT_ARE_EQUAL(int, 0, umocktypes_charptr_register_types(), "umocktypes_charptr_register_types failed");
+    ASSERT_ARE_EQUAL(int, 0, umocktypes_stdint_register_types(), "umocktypes_stdint_register_types failed");
+
+    REGISTER_GBALLOC_HL_GLOBAL_MOCK_HOOK();
+    REGISTER_INTERLOCKED_GLOBAL_MOCK_HOOK();
+
+    REGISTER_GLOBAL_MOCK_FAIL_RETURN(malloc_flex, NULL);
+
+    ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
+}
+
+TEST_SUITE_CLEANUP(suite_cleanup)
+{
+    umock_c_negative_tests_deinit();
+    umock_c_deinit();
+
+    real_gballoc_hl_deinit();
+}
+
+TEST_FUNCTION_INITIALIZE(method_init)
+{
+    umock_c_reset_all_calls();
+}
+
+TEST_FUNCTION_CLEANUP(method_cleanup)
+{
+}
+
+/* TQUEUE_CREATE */
+
+/* Tests_SRS_TQUEUE_01_001: [ If queue_size is 0, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_0_queue_size_fails)
+{
+    // arrange
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(0, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_only_push_cb_being_NULL_fails)
+{
+    // arrange
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_only_pop_cb_being_NULL_fails)
+{
+    // arrange
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, NULL, test_dispose_item, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_only_dispose_item_being_NULL_fails)
+{
+    // arrange
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, test_pop_cb_1, NULL, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_push_and_pop_cb_NULL_fails)
+{
+    // arrange
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, NULL, test_dispose_item, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_push_cb_and_dispose_item_NULL_fails)
+{
+    // arrange
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb_1, NULL, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_003: [ TQUEUE_CREATE(T) shall call THANDLE_MALLOC_FLEX with TQUEUE_DISPOSE_FUNC(T) as dispose function, nmemb set to queue_size and size set to sizeof(T). ]*/
+/* Tests_SRS_TQUEUE_01_004: [ TQUEUE_CREATE(T) shall initialize the head and tail of the list with 0 by using interlocked_exchange_64. ]*/
+/* Tests_SRS_TQUEUE_01_005: [ TQUEUE_CREATE(T) shall initialize the state for each entry in the array used for the queue with NOT_USED by using interlocked_exchange. ]*/
+/* Tests_SRS_TQUEUE_01_006: [ TQUEUE_CREATE(T) shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_all_functions_non_NULL_succeeds)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(malloc_flex(IGNORED_ARG, 1024, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, 1));
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0));
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0));
+    for (uint32_t i = 0; i < 1024; i++)
+    {
+        STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED));
+    }
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NOT_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_003: [ TQUEUE_CREATE(T) shall call THANDLE_MALLOC_FLEX with TQUEUE_DISPOSE_FUNC(T) as dispose function, nmemb set to queue_size and size set to sizeof(T). ]*/
+/* Tests_SRS_TQUEUE_01_004: [ TQUEUE_CREATE(T) shall initialize the head and tail of the list with 0 by using interlocked_exchange_64. ]*/
+/* Tests_SRS_TQUEUE_01_005: [ TQUEUE_CREATE(T) shall initialize the state for each entry in the array used for the queue with NOT_USED by using interlocked_exchange. ]*/
+/* Tests_SRS_TQUEUE_01_006: [ TQUEUE_CREATE(T) shall succeed and return a non-NULL value. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_all_functions_NULL_succeeds)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(malloc_flex(IGNORED_ARG, 1024, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, 1));
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0));
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0));
+    for (uint32_t i = 0; i < 1024; i++)
+    {
+        STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED));
+    }
+
+    // act
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, NULL, NULL, (void*)0x4242);
+
+    // assert
+    ASSERT_IS_NOT_NULL(queue);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_007: [ If there are any failures then TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(when_underlying_calls_fail_TQUEUE_CREATE_also_fails)
+{
+    // arrange
+    STRICT_EXPECTED_CALL(malloc_flex(IGNORED_ARG, 1024, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, 1))
+        .CallCannotFail();
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0))
+        .CallCannotFail();
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0))
+        .CallCannotFail();
+    for (uint32_t i = 0; i < 1024; i++)
+    {
+        STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED))
+            .CallCannotFail();
+    }
+
+    umock_c_negative_tests_snapshot();
+
+    for (uint32_t i = 0; i < umock_c_negative_tests_call_count(); i++)
+    {
+        if (umock_c_negative_tests_can_call_fail(i))
+        {
+            umock_c_negative_tests_reset();
+            umock_c_negative_tests_fail_call(i);
+
+            // act
+            TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+            // assert
+            ASSERT_IS_NULL(queue, "test failed for call %" PRIu32 "", i);
+        }
+    }
+}
+
+/* TQUEUE_DISPOSE_FUNC(T) */
+
+static TQUEUE(int32_t) test_queue_create(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(int32_t) push_cb_function, TQUEUE_POP_CB_FUNC(int32_t) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(int32_t) dispose_item_function, void* dispose_function_context)
+{
+    STRICT_EXPECTED_CALL(malloc_flex(IGNORED_ARG, queue_size, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, 1));
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0));
+    STRICT_EXPECTED_CALL(interlocked_exchange_64(IGNORED_ARG, 0));
+    for (uint32_t i = 0; i < queue_size; i++)
+    {
+        STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED));
+    }
+
+    TQUEUE(int32_t) result = TQUEUE_CREATE(int32_t)(queue_size, push_cb_function, pop_cb_function, dispose_item_function, dispose_function_context);
+    ASSERT_IS_NOT_NULL(result);
+    umock_c_reset_all_calls();
+
+    return result;
+}
+
+/* Tests_SRS_TQUEUE_01_008: [ If dispose_item_function passed to TQUEUE_CREATE(T) is NULL, TQUEUE_DISPOSE_FUNC(T) shall return. ]*/
+TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_NULL_dispose_item_returns)
+{
+    // arrange
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, (void*)0x4242);
+
+    STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(free(IGNORED_ARG));
+
+    // act
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_009: [ Otherwise, TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue head by calling interlocked_add_64. ]*/
+/* Tests_SRS_TQUEUE_01_010: [ TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue tail by calling interlocked_add_64. ]*/
+/* Tests_SRS_TQUEUE_01_011: [ For each item in the queue, dispose_item_function shall be called with dispose_function_context and a pointer to the array entry value (T*). ]*/
+TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_empty_queue_does_not_call_dispose_item)
+{
+    // arrange
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(free(IGNORED_ARG));
+
+    // act
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+static void test_queue_push(TQUEUE(int32_t) queue, int32_t item)
+{
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, TQUEUE_PUSH(int32_t)(queue, &item, NULL));
+    umock_c_reset_all_calls();
+}
+
+static int32_t test_queue_pop(TQUEUE(int32_t) queue)
+{
+    int32_t result;
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, TQUEUE_POP(int32_t)(queue, &result, NULL, NULL, NULL));
+    umock_c_reset_all_calls();
+    return result;
+}
+
+static int32_t test_queue_pop_rejected(TQUEUE(int32_t) queue)
+{
+    int32_t result;
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(test_condition_function_false((void*)0x4247, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // revert entry_state
+
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_REJECTED, TQUEUE_POP(int32_t)(queue, &result, NULL, test_condition_function_false, (void*)0x4247));
+    umock_c_reset_all_calls();
+    return result;
+}
+
+/* Tests_SRS_TQUEUE_01_009: [ Otherwise, TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue head by calling interlocked_add_64. ]*/
+/* Tests_SRS_TQUEUE_01_010: [ TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue tail by calling interlocked_add_64. ]*/
+/* Tests_SRS_TQUEUE_01_011: [ For each item in the queue, dispose_item_function shall be called with dispose_function_context and a pointer to the array entry value (T*). ]*/
+TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_1_item_calls_dispose_item_once)
+{
+    // arrange
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(test_dispose_item((void*)0x4242, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(free(IGNORED_ARG));
+
+    // act
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_009: [ Otherwise, TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue head by calling interlocked_add_64. ]*/
+/* Tests_SRS_TQUEUE_01_010: [ TQUEUE_DISPOSE_FUNC(T) shall obtain the current queue tail by calling interlocked_add_64. ]*/
+/* Tests_SRS_TQUEUE_01_011: [ For each item in the queue, dispose_item_function shall be called with dispose_function_context and a pointer to the array entry value (T*). ]*/
+TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_2_items_calls_dispose_item_2_times)
+{
+    // arrange
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    test_queue_push(queue, 42);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(test_dispose_item((void*)0x4242, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(test_dispose_item((void*)0x4242, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(free(IGNORED_ARG));
+
+    // act
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* TQUEUE_PUSH(T) */
+
+/* Tests_SRS_TQUEUE_01_012: [ If tqueue is NULL then TQUEUE_PUSH(T) shall fail and return TQUEUE_PUSH_INVALID_ARG. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_with_NULL_queue_fails)
+{
+    // arrange
+    int32_t item = 42;
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(NULL, &item, (void*)0x4243);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_INVALID_ARG, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_013: [ If item is NULL then TQUEUE_PUSH(T) shall fail and return TQUEUE_PUSH_INVALID_ARG. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_with_NULL_item_fails)
+{
+    // arrange
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, NULL, (void*)0x4243);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_INVALID_ARG, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_014: [ TQUEUE_PUSH(T) shall execute the following actions until it is either able to push the item in the queue or the queue is full: ]*/
+    /* Tests_SRS_TQUEUE_01_015: [ TQUEUE_PUSH(T) shall obtain the current head queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_016: [ TQUEUE_PUSH(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_017: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall change the head array entry state to PUSHING (from NOT_USED). ]*/
+    /* Tests_SRS_TQUEUE_01_018: [ Using interlocked_compare_exchange_64, TQUEUE_PUSH(T) shall replace the head value with the head value obtained earlier + 1. ]*/
+    /* Tests_SRS_TQUEUE_01_019: [ If no push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall copy the value of item into the array entry value whose state was changed to PUSHING. ]*/
+    /* Tests_SRS_TQUEUE_01_020: [ TQUEUE_PUSH(T) shall set the state to USED by using interlocked_exchange. ]*/
+    /* Tests_SRS_TQUEUE_01_021: [ TQUEUE_PUSH(T) shall succeed and return TQUEUE_PUSH_OK. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_with_valid_args_without_push_cb_func_copies_the_data_in)
+{
+    // arrange
+    int32_t item = 42;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, &item, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_014: [ TQUEUE_PUSH(T) shall execute the following actions until it is either able to push the item in the queue or the queue is full: ]*/
+    /* Tests_SRS_TQUEUE_01_015: [ TQUEUE_PUSH(T) shall obtain the current head queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_016: [ TQUEUE_PUSH(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_017: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall change the head array entry state to PUSHING (from NOT_USED). ]*/
+    /* Tests_SRS_TQUEUE_01_018: [ Using interlocked_compare_exchange_64, TQUEUE_PUSH(T) shall replace the head value with the head value obtained earlier + 1. ]*/
+    /* Tests_SRS_TQUEUE_01_019: [ If no push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall copy the value of item into the array entry value whose state was changed to PUSHING. ]*/
+    /* Tests_SRS_TQUEUE_01_020: [ TQUEUE_PUSH(T) shall set the state to USED by using interlocked_exchange. ]*/
+    /* Tests_SRS_TQUEUE_01_021: [ TQUEUE_PUSH(T) shall succeed and return TQUEUE_PUSH_OK. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_twice_copies_the_data_in)
+{
+    // arrange
+    int32_t item_1 = 42;
+    int32_t item_2 = 43;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    // act
+    TQUEUE_PUSH_RESULT result_1 = TQUEUE_PUSH(int32_t)(queue, &item_1, NULL);
+    TQUEUE_PUSH_RESULT result_2 = TQUEUE_PUSH(int32_t)(queue, &item_2, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result_1);
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result_2);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_022: [ If the queue is full (current head >= current tail + queue size), TQUEUE_PUSH(T) shall return TQUEUE_PUSH_QUEUE_FULL. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_twice_for_queue_size_1_returns_QUEUE_FULL)
+{
+    // arrange
+    int32_t item = 42;
+    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, &item, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_QUEUE_FULL, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_043: [ If the queue head has changed, TQUEUE_PUSH(T) shall try again. ]*/
+TEST_FUNCTION(when_head_changes_TQUEUE_PUSH_tries_again)
+{
+    // arrange
+    int32_t item = 42;
+    TQUEUE(int32_t) queue = test_queue_create(2, NULL, NULL, NULL, NULL);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0))
+        .SetReturn(1); // head changed!
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, &item, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+static void test_TQUEUE_PUSH_when_entry_state_is_different_than_NOT_USED_tries_again(QUEUE_ENTRY_STATE queue_entry_state)
+{
+    // arrange
+    int32_t item = 42;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED))
+        .SetReturn(queue_entry_state); // fail change one time
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED))
+        .SetReturn(queue_entry_state); // fail change 2 times, just for fun
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, &item, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_023: [ If the state of the array entry corresponding to the head is not NOT_USED, TQUEUE_PUSH(T) shall try changing the state again. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_when_entry_state_is_PUSHING_tries_again)
+{
+    test_TQUEUE_PUSH_when_entry_state_is_different_than_NOT_USED_tries_again(QUEUE_ENTRY_STATE_PUSHING);
+}
+
+/* Tests_SRS_TQUEUE_01_023: [ If the state of the array entry corresponding to the head is not NOT_USED, TQUEUE_PUSH(T) shall try changing the state again. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_when_entry_state_is_POPPING_tries_again)
+{
+    test_TQUEUE_PUSH_when_entry_state_is_different_than_NOT_USED_tries_again(QUEUE_ENTRY_STATE_POPPING);
+}
+
+/* Tests_SRS_TQUEUE_01_023: [ If the state of the array entry corresponding to the head is not NOT_USED, TQUEUE_PUSH(T) shall try changing the state again. ]*/
+TEST_FUNCTION(TQUEUE_PUSH_when_entry_state_is_USED_tries_again)
+{
+    test_TQUEUE_PUSH_when_entry_state_is_different_than_NOT_USED_tries_again(QUEUE_ENTRY_STATE_USED);
+}
+
+/* Tests_SRS_TQUEUE_01_024: [ If a push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall call the push_cb_function with push_cb_function_context as context, a pointer to the array entry value whose state was changed to PUSHING as push_dst and item as push_src. ] */
+TEST_FUNCTION(TQUEUE_PUSH_with_push_cb_function_calls_the_cb_function)
+{
+    // arrange
+    int32_t item = 42;
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
+    STRICT_EXPECTED_CALL(test_push_cb_1((void*)0x4243, IGNORED_ARG, &item)); // entry state
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    // act
+    TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, &item, (void*)0x4243);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_024: [ If a push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall call the push_cb_function with push_cb_function_context as context, a pointer to the array entry value whose state was changed to PUSHING as push_dst and item as push_src. ] */
+TEST_FUNCTION(TQUEUE_PUSH_with_push_cb_function_calls_the_cb_function_2_items)
+{
+    // arrange
+    int32_t item_1 = 42;
+    int32_t item_2 = 43;
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
+    STRICT_EXPECTED_CALL(test_push_cb_1((void*)0x4243, IGNORED_ARG, &item_1)); // entry state
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // head change
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
+    STRICT_EXPECTED_CALL(test_push_cb_1((void*)0x4244, IGNORED_ARG, &item_2)); // entry state
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
+
+    // act
+    TQUEUE_PUSH_RESULT result_1 = TQUEUE_PUSH(int32_t)(queue, &item_1, (void*)0x4243);
+    TQUEUE_PUSH_RESULT result_2 = TQUEUE_PUSH(int32_t)(queue, &item_2, (void*)0x4244);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result_1);
+    ASSERT_ARE_EQUAL(TQUEUE_PUSH_RESULT, TQUEUE_PUSH_OK, result_2);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* TQUEUE_POP(T) */
+
+/* Tests_SRS_TQUEUE_01_025: [ If tqueue is NULL then TQUEUE_POP(T) shall fail and return TQUEUE_POP_INVALID_ARG. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_NULL_tqueue_fails)
+{
+    // arrange
+    int32_t item = 45;
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(NULL, &item, (void*)0x4243, test_condition_function_true, (void*)0x4244);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_INVALID_ARG, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+}
+
+/* Tests_SRS_TQUEUE_01_027: [ If item is NULL then TQUEUE_POP(T) shall fail and return TQUEUE_POP_INVALID_ARG. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_NULL_item_fails)
+{
+    // arrange
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, NULL, (void*)0x4243, test_condition_function_true, (void*)0x4244);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_INVALID_ARG, result);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_026: [ TQUEUE_POP(T) shall execute the following actions until it is either able to pop the item from the queue or the queue is empty: ] */
+    /* Tests_SRS_TQUEUE_01_028: [ TQUEUE_POP(T) shall obtain the current head queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_029: [ TQUEUE_POP(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_030: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall set the tail array entry state to POPPING (from USED). ]*/
+    /* Tests_SRS_TQUEUE_01_031: [ TQUEUE_POP(T) shall replace the tail value with the tail value obtained earlier + 1 by using interlocked_exchange_64. ]*/
+    /* Tests_SRS_TQUEUE_01_032: [ If a pop_cb_function was not specified in TQUEUE_CREATE(T): ]*/
+    /* Tests_SRS_TQUEUE_01_033: [ TQUEUE_POP(T) shall copy array entry value whose state was changed to POPPING to item. ]*/
+    /* Tests_SRS_TQUEUE_01_034: [ TQUEUE_POP(T) shall set the state to NOT_USED by using interlocked_exchange, succeed and return TQUEUE_POP_OK. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_NULL_condition_function_succeeds)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result);
+    ASSERT_ARE_EQUAL(int32_t, 42, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_026: [ TQUEUE_POP(T) shall execute the following actions until it is either able to pop the item from the queue or the queue is empty: ] */
+    /* Tests_SRS_TQUEUE_01_028: [ TQUEUE_POP(T) shall obtain the current head queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_029: [ TQUEUE_POP(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
+    /* Tests_SRS_TQUEUE_01_030: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall set the tail array entry state to POPPING (from USED). ]*/
+    /* Tests_SRS_TQUEUE_01_031: [ TQUEUE_POP(T) shall replace the tail value with the tail value obtained earlier + 1 by using interlocked_exchange_64. ]*/
+    /* Tests_SRS_TQUEUE_01_032: [ If a pop_cb_function was not specified in TQUEUE_CREATE(T): ]*/
+    /* Tests_SRS_TQUEUE_01_033: [ TQUEUE_POP(T) shall copy array entry value whose state was changed to POPPING to item. ]*/
+    /* Tests_SRS_TQUEUE_01_034: [ TQUEUE_POP(T) shall set the state to NOT_USED by using interlocked_exchange, succeed and return TQUEUE_POP_OK. ]*/
+TEST_FUNCTION(TQUEUE_POP_twice_with_NULL_pop_cb_function_and_NULL_condition_function_succeeds)
+{
+    // arrange
+    int32_t item_1 = 45;
+    int32_t item_2 = 46;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+    test_queue_push(queue, 43);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result_1 = TQUEUE_POP(int32_t)(queue, &item_1, NULL, NULL, NULL);
+    TQUEUE_POP_RESULT result_2 = TQUEUE_POP(int32_t)(queue, &item_2, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result_1);
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result_2);
+    ASSERT_ARE_EQUAL(int32_t, 42, item_1);
+    ASSERT_ARE_EQUAL(int32_t, 43, item_2);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail == current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
+TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_returns_QUEUE_EMPTY)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_QUEUE_EMPTY, result);
+    ASSERT_ARE_EQUAL(int32_t, 45, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail == current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
+TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_and_queue_size_1_returns_QUEUE_EMPTY)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL, NULL);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_QUEUE_EMPTY, result);
+    ASSERT_ARE_EQUAL(int32_t, 45, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail == current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
+TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_after_a_push_and_a_pop_and_queue_size_1_returns_QUEUE_EMPTY)
+{
+    // arrange
+    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+    ASSERT_ARE_EQUAL(int32_t, 42, test_queue_pop(queue));
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+
+    // act
+    int32_t item = 45;
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_QUEUE_EMPTY, result);
+    ASSERT_ARE_EQUAL(int32_t, 45, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+static void test_TQUEUE_POP_when_entry_state_is_different_than_USED_tries_again(QUEUE_ENTRY_STATE queue_entry_state)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED))
+        .SetReturn(queue_entry_state); // entry_state
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // retry for entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result);
+    ASSERT_ARE_EQUAL(int32_t, 42, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_036: [ If the state of the array entry corresponding to the tail is not USED, TQUEUE_POP(T) shall try again. ]*/
+TEST_FUNCTION(TQUEUE_POP_when_entry_state_is_PUSHING_tries_again)
+{
+    test_TQUEUE_POP_when_entry_state_is_different_than_USED_tries_again(QUEUE_ENTRY_STATE_PUSHING);
+}
+
+/* Tests_SRS_TQUEUE_01_036: [ If the state of the array entry corresponding to the tail is not USED, TQUEUE_POP(T) shall try again. ]*/
+TEST_FUNCTION(TQUEUE_POP_when_entry_state_is_POPPING_tries_again)
+{
+    test_TQUEUE_POP_when_entry_state_is_different_than_USED_tries_again(QUEUE_ENTRY_STATE_POPPING);
+}
+
+/* Tests_SRS_TQUEUE_01_036: [ If the state of the array entry corresponding to the tail is not USED, TQUEUE_POP(T) shall try again. ]*/
+TEST_FUNCTION(TQUEUE_POP_when_entry_state_is_NOT_USED_tries_again)
+{
+    test_TQUEUE_POP_when_entry_state_is_different_than_USED_tries_again(QUEUE_ENTRY_STATE_NOT_USED);
+}
+
+/* Tests_SRS_TQUEUE_01_037: [ If a pop_cb_function was specified in TQUEUE_CREATE(T): ]*/
+/* Tests_SRS_TQUEUE_01_038: [ TQUEUE_POP(T) shall call pop_cb_function with pop_cb_function_context as context, the array entry value whose state was changed to POPPING to item as pop_src and item as pop_dst. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_succeeds)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4243, &item, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, (void*)0x4243, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result);
+    ASSERT_ARE_EQUAL(int32_t, 42, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_037: [ If a pop_cb_function was specified in TQUEUE_CREATE(T): ]*/
+/* Tests_SRS_TQUEUE_01_038: [ TQUEUE_POP(T) shall call pop_cb_function with pop_cb_function_context as context, the array entry value whose state was changed to POPPING to item as pop_src and item as pop_dst. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_twice_succeeds)
+{
+    // arrange
+    int32_t item_1 = 45;
+    int32_t item_2 = 46;
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    test_queue_push(queue, 42);
+    test_queue_push(queue, 43);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4243, &item_1, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4244, &item_2, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result_1 = TQUEUE_POP(int32_t)(queue, &item_1, (void*)0x4243, NULL, NULL);
+    TQUEUE_POP_RESULT result_2 = TQUEUE_POP(int32_t)(queue, &item_2, (void*)0x4244, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result_1);
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result_2);
+    ASSERT_ARE_EQUAL(int32_t, 42, item_1);
+    ASSERT_ARE_EQUAL(int32_t, 43, item_2);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_039: [ If condition_function is not NULL: ]*/
+/* Tests_SRS_TQUEUE_01_040: [ TQUEUE_POP(T) shall call condition_function with condition_function_context and a pointer to the array entry value whose state was changed to POPPING. ] */ \
+/* Tests_SRS_TQUEUE_01_042: [ Otherwise, shall proceed with the pop. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_non_NULL_condition_function_succeeds)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(test_condition_function_true((void*)0x4247, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, test_condition_function_true, (void*)0x4247);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result);
+    ASSERT_ARE_EQUAL(int32_t, 42, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_041: [ If condition_function returns false, TQUEUE_POP(T) shall set the state to USED by using interlocked_exchange and return TQUEUE_POP_REJECTED. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_non_NULL_condition_function_returning_false_does_not_pop)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(test_condition_function_false((void*)0x4247, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // revert entry_state
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, test_condition_function_false, (void*)0x4247);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_REJECTED, result);
+    ASSERT_ARE_EQUAL(int32_t, 45, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_039: [ If condition_function is not NULL: ]*/
+/* Tests_SRS_TQUEUE_01_040: [ TQUEUE_POP(T) shall call condition_function with condition_function_context and a pointer to the array entry value whose state was changed to POPPING. ] */ \
+/* Tests_SRS_TQUEUE_01_042: [ Otherwise, shall proceed with the pop. ]*/
+TEST_FUNCTION(TQUEUE_POP_after_a_POP_that_was_rejected_succeeds)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    test_queue_push(queue, 42);
+    test_queue_pop_rejected(queue);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(test_condition_function_true((void*)0x4248, IGNORED_ARG));
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, NULL, test_condition_function_true, (void*)0x4248);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result);
+    ASSERT_ARE_EQUAL(int32_t, 42, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+/* Tests_SRS_TQUEUE_01_044: [ If incrementing the tail by using interlocked_compare_exchange_64 does not succeed, TQUEUE_POP(T) shall revert the state of the array entry to USED and retry. ]*/
+TEST_FUNCTION(when_switching_the_tail_does_not_succeed_TQUEUE_POP_retries)
+{
+    // arrange
+    int32_t item = 45;
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb_1, test_pop_cb_1, test_dispose_item, (void*)0x4242);
+    test_queue_push(queue, 42);
+
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0))
+        .SetReturn(1); // tail changed
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // revert entry_state
+
+    // restart
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
+    STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
+    STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
+    STRICT_EXPECTED_CALL(test_pop_cb_1((void*)0x4243, &item, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
+
+    // act
+    TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, &item, (void*)0x4243, NULL, NULL);
+
+    // assert
+    ASSERT_ARE_EQUAL(TQUEUE_POP_RESULT, TQUEUE_POP_OK, result);
+    ASSERT_ARE_EQUAL(int32_t, 42, item);
+    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
+
+    // clean
+    TQUEUE_ASSIGN(int32_t)(&queue, NULL);
+}
+
+END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)

--- a/tests/tqueue_ut/tqueue_ut.c
+++ b/tests/tqueue_ut/tqueue_ut.c
@@ -46,12 +46,8 @@ TQUEUE_TYPE_DECLARE(int32_t);
 THANDLE_TYPE_DEFINE(TQUEUE_TYPEDEF_NAME(int32_t))
 TQUEUE_TYPE_DEFINE(int32_t);
 
-MOCK_FUNCTION_WITH_CODE(, void, test_push_cb, void*, context, int32_t*, push_dst, int32_t*, push_src)
-    *push_dst = *push_src;
-MOCK_FUNCTION_END();
-
-MOCK_FUNCTION_WITH_CODE(, void, test_pop_cb, void*, context, int32_t*, pop_dst, int32_t*, pop_src)
-    *pop_dst = *pop_src;
+MOCK_FUNCTION_WITH_CODE(, void, test_copy_item, void*, context, int32_t*, dst, int32_t*, src)
+    *dst = *src;
 MOCK_FUNCTION_END();
 
 MOCK_FUNCTION_WITH_CODE(, void, test_dispose_item, void*, context, int32_t*, item)
@@ -112,72 +108,33 @@ TEST_FUNCTION(TQUEUE_CREATE_with_0_queue_size_fails)
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(0, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(0, test_copy_item, test_dispose_item, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
-TEST_FUNCTION(TQUEUE_CREATE_with_only_push_cb_being_NULL_fails)
+/* Tests_SRS_TQUEUE_01_002: [ If any of copy_item_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+TEST_FUNCTION(TQUEUE_CREATE_with_only_copy_item_function_being_NULL_fails)
 {
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_dispose_item, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
-TEST_FUNCTION(TQUEUE_CREATE_with_only_pop_cb_being_NULL_fails)
-{
-    // arrange
-
-    // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, NULL, test_dispose_item, (void*)0x4242);
-
-    // assert
-    ASSERT_IS_NULL(queue);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-}
-
-/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
+/* Tests_SRS_TQUEUE_01_002: [ If any of copy_item_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
 TEST_FUNCTION(TQUEUE_CREATE_with_only_dispose_item_being_NULL_fails)
 {
     // arrange
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, test_pop_cb, NULL, (void*)0x4242);
-
-    // assert
-    ASSERT_IS_NULL(queue);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-}
-
-/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
-TEST_FUNCTION(TQUEUE_CREATE_with_push_and_pop_cb_NULL_fails)
-{
-    // arrange
-
-    // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, NULL, test_dispose_item, (void*)0x4242);
-
-    // assert
-    ASSERT_IS_NULL(queue);
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-}
-
-/* Tests_SRS_TQUEUE_01_002: [ If any of push_cb_function, pop_cb_function and dispose_item_function is NULL and at least one of them is not NULL, TQUEUE_CREATE(T) shall fail and return NULL. ]*/
-TEST_FUNCTION(TQUEUE_CREATE_with_push_cb_and_dispose_item_NULL_fails)
-{
-    // arrange
-
-    // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, test_pop_cb, NULL, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_copy_item, NULL, (void*)0x4242);
 
     // assert
     ASSERT_IS_NULL(queue);
@@ -201,7 +158,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_all_functions_non_NULL_succeeds)
     }
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_copy_item, test_dispose_item, (void*)0x4242);
 
     // assert
     ASSERT_IS_NOT_NULL(queue);
@@ -228,7 +185,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_all_functions_NULL_succeeds)
     }
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, NULL, NULL, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, NULL, (void*)0x4242);
 
     // assert
     ASSERT_IS_NOT_NULL(queue);
@@ -265,7 +222,7 @@ TEST_FUNCTION(when_underlying_calls_fail_TQUEUE_CREATE_also_fails)
             umock_c_negative_tests_fail_call(i);
 
             // act
-            TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+            TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, test_copy_item, test_dispose_item, (void*)0x4242);
 
             // assert
             ASSERT_IS_NULL(queue, "test failed for call %" PRIu32 "", i);
@@ -275,7 +232,7 @@ TEST_FUNCTION(when_underlying_calls_fail_TQUEUE_CREATE_also_fails)
 
 /* TQUEUE_DISPOSE_FUNC(T) */
 
-static TQUEUE(int32_t) test_queue_create(uint32_t queue_size, TQUEUE_PUSH_CB_FUNC(int32_t) push_cb_function, TQUEUE_POP_CB_FUNC(int32_t) pop_cb_function, TQUEUE_DISPOSE_ITEM_FUNC(int32_t) dispose_item_function, void* dispose_function_context)
+static TQUEUE(int32_t) test_queue_create(uint32_t queue_size, TQUEUE_COPY_ITEM_FUNC(int32_t) copy_item_function, TQUEUE_DISPOSE_ITEM_FUNC(int32_t) dispose_item_function, void* dispose_function_context)
 {
     STRICT_EXPECTED_CALL(malloc_flex(IGNORED_ARG, queue_size, IGNORED_ARG));
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, 1));
@@ -286,7 +243,7 @@ static TQUEUE(int32_t) test_queue_create(uint32_t queue_size, TQUEUE_PUSH_CB_FUN
         STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED));
     }
 
-    TQUEUE(int32_t) result = TQUEUE_CREATE(int32_t)(queue_size, push_cb_function, pop_cb_function, dispose_item_function, dispose_function_context);
+    TQUEUE(int32_t) result = TQUEUE_CREATE(int32_t)(queue_size, copy_item_function, dispose_item_function, dispose_function_context);
     ASSERT_IS_NOT_NULL(result);
     umock_c_reset_all_calls();
 
@@ -297,7 +254,7 @@ static TQUEUE(int32_t) test_queue_create(uint32_t queue_size, TQUEUE_PUSH_CB_FUN
 TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_NULL_dispose_item_returns)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, (void*)0x4242);
 
     STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
     STRICT_EXPECTED_CALL(free(IGNORED_ARG));
@@ -315,7 +272,7 @@ TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_NULL_dispose_item_returns)
 TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_empty_queue_does_not_call_dispose_item)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
 
     STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -364,7 +321,7 @@ static int32_t test_queue_pop_rejected(TQUEUE(int32_t) queue)
 TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_1_item_calls_dispose_item_once)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_decrement(IGNORED_ARG));
@@ -386,7 +343,7 @@ TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_1_item_calls_d
 TEST_FUNCTION(TQUEUE_DISPOSE_FUNC_with_non_NULL_dispose_item_with_2_items_calls_dispose_item_2_times)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
     test_queue_push(queue, 42);
 
@@ -424,7 +381,7 @@ TEST_FUNCTION(TQUEUE_PUSH_with_NULL_queue_fails)
 TEST_FUNCTION(TQUEUE_PUSH_with_NULL_item_fails)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
 
     // act
     TQUEUE_PUSH_RESULT result = TQUEUE_PUSH(int32_t)(queue, NULL, (void*)0x4243);
@@ -442,14 +399,14 @@ TEST_FUNCTION(TQUEUE_PUSH_with_NULL_item_fails)
     /* Tests_SRS_TQUEUE_01_016: [ TQUEUE_PUSH(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
     /* Tests_SRS_TQUEUE_01_017: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall change the head array entry state to PUSHING (from NOT_USED). ]*/
     /* Tests_SRS_TQUEUE_01_018: [ Using interlocked_compare_exchange_64, TQUEUE_PUSH(T) shall replace the head value with the head value obtained earlier + 1. ]*/
-    /* Tests_SRS_TQUEUE_01_019: [ If no push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall copy the value of item into the array entry value whose state was changed to PUSHING. ]*/
+    /* Tests_SRS_TQUEUE_01_019: [ If no copy_item_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall copy the value of item into the array entry value whose state was changed to PUSHING. ]*/
     /* Tests_SRS_TQUEUE_01_020: [ TQUEUE_PUSH(T) shall set the state to USED by using interlocked_exchange. ]*/
     /* Tests_SRS_TQUEUE_01_021: [ TQUEUE_PUSH(T) shall succeed and return TQUEUE_PUSH_OK. ]*/
 TEST_FUNCTION(TQUEUE_PUSH_with_valid_args_without_push_cb_func_copies_the_data_in)
 {
     // arrange
     int32_t item = 42;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
@@ -473,7 +430,7 @@ TEST_FUNCTION(TQUEUE_PUSH_with_valid_args_without_push_cb_func_copies_the_data_i
     /* Tests_SRS_TQUEUE_01_016: [ TQUEUE_PUSH(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
     /* Tests_SRS_TQUEUE_01_017: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall change the head array entry state to PUSHING (from NOT_USED). ]*/
     /* Tests_SRS_TQUEUE_01_018: [ Using interlocked_compare_exchange_64, TQUEUE_PUSH(T) shall replace the head value with the head value obtained earlier + 1. ]*/
-    /* Tests_SRS_TQUEUE_01_019: [ If no push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall copy the value of item into the array entry value whose state was changed to PUSHING. ]*/
+    /* Tests_SRS_TQUEUE_01_019: [ If no copy_item_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall copy the value of item into the array entry value whose state was changed to PUSHING. ]*/
     /* Tests_SRS_TQUEUE_01_020: [ TQUEUE_PUSH(T) shall set the state to USED by using interlocked_exchange. ]*/
     /* Tests_SRS_TQUEUE_01_021: [ TQUEUE_PUSH(T) shall succeed and return TQUEUE_PUSH_OK. ]*/
 TEST_FUNCTION(TQUEUE_PUSH_twice_copies_the_data_in)
@@ -481,7 +438,7 @@ TEST_FUNCTION(TQUEUE_PUSH_twice_copies_the_data_in)
     // arrange
     int32_t item_1 = 42;
     int32_t item_2 = 43;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
@@ -513,7 +470,7 @@ TEST_FUNCTION(TQUEUE_PUSH_twice_for_queue_size_1_returns_QUEUE_FULL)
 {
     // arrange
     int32_t item = 42;
-    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -535,7 +492,7 @@ TEST_FUNCTION(when_head_changes_TQUEUE_PUSH_tries_again)
 {
     // arrange
     int32_t item = 42;
-    TQUEUE(int32_t) queue = test_queue_create(2, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(2, NULL, NULL, NULL);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
@@ -563,7 +520,7 @@ static void test_TQUEUE_PUSH_when_entry_state_is_different_than_NOT_USED_tries_a
 {
     // arrange
     int32_t item = 42;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
@@ -604,18 +561,18 @@ TEST_FUNCTION(TQUEUE_PUSH_when_entry_state_is_USED_tries_again)
     test_TQUEUE_PUSH_when_entry_state_is_different_than_NOT_USED_tries_again(QUEUE_ENTRY_STATE_USED);
 }
 
-/* Tests_SRS_TQUEUE_01_024: [ If a push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall call the push_cb_function with push_cb_function_context as context, a pointer to the array entry value whose state was changed to PUSHING as push_dst and item as push_src. ] */
-TEST_FUNCTION(TQUEUE_PUSH_with_push_cb_function_calls_the_cb_function)
+/* Tests_SRS_TQUEUE_01_024: [ If a copy_item_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall call the copy_item_function with copy_item_function_context as context, a pointer to the array entry value whose state was changed to PUSHING as push_dst and item as push_src. ] */
+TEST_FUNCTION(TQUEUE_PUSH_with_copy_item_function_calls_the_cb_function)
 {
     // arrange
     int32_t item = 42;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
-    STRICT_EXPECTED_CALL(test_push_cb((void*)0x4243, IGNORED_ARG, &item)); // entry state
+    STRICT_EXPECTED_CALL(test_copy_item((void*)0x4243, IGNORED_ARG, &item)); // entry state
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
 
     // act
@@ -629,26 +586,26 @@ TEST_FUNCTION(TQUEUE_PUSH_with_push_cb_function_calls_the_cb_function)
     TQUEUE_ASSIGN(int32_t)(&queue, NULL);
 }
 
-/* Tests_SRS_TQUEUE_01_024: [ If a push_cb_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall call the push_cb_function with push_cb_function_context as context, a pointer to the array entry value whose state was changed to PUSHING as push_dst and item as push_src. ] */
-TEST_FUNCTION(TQUEUE_PUSH_with_push_cb_function_calls_the_cb_function_2_items)
+/* Tests_SRS_TQUEUE_01_024: [ If a copy_item_function was specified in TQUEUE_CREATE(T), TQUEUE_PUSH(T) shall call the copy_item_function with copy_item_function_context as context, a pointer to the array entry value whose state was changed to PUSHING as push_dst and item as push_src. ] */
+TEST_FUNCTION(TQUEUE_PUSH_with_copy_item_function_calls_the_cb_function_2_items)
 {
     // arrange
     int32_t item_1 = 42;
     int32_t item_2 = 43;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // head change
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
-    STRICT_EXPECTED_CALL(test_push_cb((void*)0x4243, IGNORED_ARG, &item_1)); // entry state
+    STRICT_EXPECTED_CALL(test_copy_item((void*)0x4243, IGNORED_ARG, &item_1)); // entry state
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // head change
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_PUSHING, QUEUE_ENTRY_STATE_NOT_USED)); // entry state
-    STRICT_EXPECTED_CALL(test_push_cb((void*)0x4244, IGNORED_ARG, &item_2)); // entry state
+    STRICT_EXPECTED_CALL(test_copy_item((void*)0x4244, IGNORED_ARG, &item_2)); // entry state
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_USED)); // entry state
 
     // act
@@ -684,7 +641,7 @@ TEST_FUNCTION(TQUEUE_POP_with_NULL_tqueue_fails)
 TEST_FUNCTION(TQUEUE_POP_with_NULL_item_fails)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
 
     // act
     TQUEUE_POP_RESULT result = TQUEUE_POP(int32_t)(queue, NULL, (void*)0x4243, test_condition_function_true, (void*)0x4244);
@@ -702,14 +659,14 @@ TEST_FUNCTION(TQUEUE_POP_with_NULL_item_fails)
     /* Tests_SRS_TQUEUE_01_029: [ TQUEUE_POP(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
     /* Tests_SRS_TQUEUE_01_030: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall set the tail array entry state to POPPING (from USED). ]*/
     /* Tests_SRS_TQUEUE_01_031: [ TQUEUE_POP(T) shall replace the tail value with the tail value obtained earlier + 1 by using interlocked_exchange_64. ]*/
-    /* Tests_SRS_TQUEUE_01_032: [ If a pop_cb_function was not specified in TQUEUE_CREATE(T): ]*/
+    /* Tests_SRS_TQUEUE_01_032: [ If a copy_item_function was not specified in TQUEUE_CREATE(T): ]*/
     /* Tests_SRS_TQUEUE_01_033: [ TQUEUE_POP(T) shall copy array entry value whose state was changed to POPPING to item. ]*/
     /* Tests_SRS_TQUEUE_01_034: [ TQUEUE_POP(T) shall set the state to NOT_USED by using interlocked_exchange, succeed and return TQUEUE_POP_OK. ]*/
-TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_NULL_condition_function_succeeds)
+TEST_FUNCTION(TQUEUE_POP_with_NULL_copy_item_function_and_NULL_condition_function_succeeds)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -735,15 +692,15 @@ TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_NULL_condition_function_s
     /* Tests_SRS_TQUEUE_01_029: [ TQUEUE_POP(T) shall obtain the current tail queue by calling interlocked_add_64. ]*/
     /* Tests_SRS_TQUEUE_01_030: [ Using interlocked_compare_exchange, TQUEUE_PUSH(T) shall set the tail array entry state to POPPING (from USED). ]*/
     /* Tests_SRS_TQUEUE_01_031: [ TQUEUE_POP(T) shall replace the tail value with the tail value obtained earlier + 1 by using interlocked_exchange_64. ]*/
-    /* Tests_SRS_TQUEUE_01_032: [ If a pop_cb_function was not specified in TQUEUE_CREATE(T): ]*/
+    /* Tests_SRS_TQUEUE_01_032: [ If a copy_item_function was not specified in TQUEUE_CREATE(T): ]*/
     /* Tests_SRS_TQUEUE_01_033: [ TQUEUE_POP(T) shall copy array entry value whose state was changed to POPPING to item. ]*/
     /* Tests_SRS_TQUEUE_01_034: [ TQUEUE_POP(T) shall set the state to NOT_USED by using interlocked_exchange, succeed and return TQUEUE_POP_OK. ]*/
-TEST_FUNCTION(TQUEUE_POP_twice_with_NULL_pop_cb_function_and_NULL_condition_function_succeeds)
+TEST_FUNCTION(TQUEUE_POP_twice_with_NULL_copy_item_function_and_NULL_condition_function_succeeds)
 {
     // arrange
     int32_t item_1 = 45;
     int32_t item_2 = 46;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
     test_queue_push(queue, 42);
     test_queue_push(queue, 43);
 
@@ -779,7 +736,7 @@ TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_returns_QUEUE_EMPTY)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
@@ -801,7 +758,7 @@ TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_and_queue_size_1_returns_QUEUE_EMPT
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
@@ -822,7 +779,7 @@ TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_and_queue_size_1_returns_QUEUE_EMPT
 TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_after_a_push_and_a_pop_and_queue_size_1_returns_QUEUE_EMPTY)
 {
     // arrange
-    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1, NULL, NULL, NULL);
     test_queue_push(queue, 42);
     ASSERT_ARE_EQUAL(int32_t, 42, test_queue_pop(queue));
 
@@ -846,7 +803,7 @@ static void test_TQUEUE_POP_when_entry_state_is_different_than_USED_tries_again(
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -890,20 +847,22 @@ TEST_FUNCTION(TQUEUE_POP_when_entry_state_is_NOT_USED_tries_again)
     test_TQUEUE_POP_when_entry_state_is_different_than_USED_tries_again(QUEUE_ENTRY_STATE_NOT_USED);
 }
 
-/* Tests_SRS_TQUEUE_01_037: [ If a pop_cb_function was specified in TQUEUE_CREATE(T): ]*/
-/* Tests_SRS_TQUEUE_01_038: [ TQUEUE_POP(T) shall call pop_cb_function with pop_cb_function_context as context, the array entry value whose state was changed to POPPING to item as pop_src and item as pop_dst. ]*/
-TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_succeeds)
+/* Tests_SRS_TQUEUE_01_037: [ If copy_item_function and sispose_item_function were specified in TQUEUE_CREATE(T): ]*/
+/* Tests_SRS_TQUEUE_01_038: [ TQUEUE_POP(T) shall call copy_item_function with copy_item_function_context as context, the array entry value whose state was changed to POPPING to item as pop_src and item as pop_dst. ]*/
+/* Tests_SRS_TQUEUE_01_045: [ TQUEUE_POP(T) shall call dispose_item_function with dispose_item_function_context as context and the array entry value whose state was changed to POPPING as item. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_copy_item_function_succeeds)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4243, &item, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_copy_item((void*)0x4243, &item, IGNORED_ARG)); // copy
+    STRICT_EXPECTED_CALL(test_dispose_item((void*)0x4242, IGNORED_ARG)); // dispose
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     // act
@@ -918,14 +877,14 @@ TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_succeeds)
     TQUEUE_ASSIGN(int32_t)(&queue, NULL);
 }
 
-/* Tests_SRS_TQUEUE_01_037: [ If a pop_cb_function was specified in TQUEUE_CREATE(T): ]*/
-/* Tests_SRS_TQUEUE_01_038: [ TQUEUE_POP(T) shall call pop_cb_function with pop_cb_function_context as context, the array entry value whose state was changed to POPPING to item as pop_src and item as pop_dst. ]*/
-TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_twice_succeeds)
+/* Tests_SRS_TQUEUE_01_037: [ If copy_item_function and sispose_item_function were specified in TQUEUE_CREATE(T): ]*/
+/* Tests_SRS_TQUEUE_01_038: [ TQUEUE_POP(T) shall call copy_item_function with copy_item_function_context as context, the array entry value whose state was changed to POPPING to item as pop_src and item as pop_dst. ]*/
+TEST_FUNCTION(TQUEUE_POP_with_copy_item_function_twice_succeeds)
 {
     // arrange
     int32_t item_1 = 45;
     int32_t item_2 = 46;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
     test_queue_push(queue, 43);
 
@@ -933,14 +892,16 @@ TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_twice_succeeds)
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4243, &item_1, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_copy_item((void*)0x4243, &item_1, IGNORED_ARG)); // copy
+    STRICT_EXPECTED_CALL(test_dispose_item((void*)0x4242, IGNORED_ARG)); // dispose
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 2, 1)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4244, &item_2, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_copy_item((void*)0x4244, &item_2, IGNORED_ARG)); //copy
+    STRICT_EXPECTED_CALL(test_dispose_item((void*)0x4242, IGNORED_ARG)); // dispose
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     // act
@@ -961,11 +922,11 @@ TEST_FUNCTION(TQUEUE_POP_with_pop_cb_function_twice_succeeds)
 /* Tests_SRS_TQUEUE_01_039: [ If condition_function is not NULL: ]*/
 /* Tests_SRS_TQUEUE_01_040: [ TQUEUE_POP(T) shall call condition_function with condition_function_context and a pointer to the array entry value whose state was changed to POPPING. ] */ \
 /* Tests_SRS_TQUEUE_01_042: [ Otherwise, shall proceed with the pop. ]*/
-TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_non_NULL_condition_function_succeeds)
+TEST_FUNCTION(TQUEUE_POP_with_NULL_copy_item_function_and_non_NULL_condition_function_succeeds)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -988,11 +949,11 @@ TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_non_NULL_condition_functi
 }
 
 /* Tests_SRS_TQUEUE_01_041: [ If condition_function returns false, TQUEUE_POP(T) shall set the state to USED by using interlocked_exchange and return TQUEUE_POP_REJECTED. ]*/
-TEST_FUNCTION(TQUEUE_POP_with_NULL_pop_cb_function_and_non_NULL_condition_function_returning_false_does_not_pop)
+TEST_FUNCTION(TQUEUE_POP_with_NULL_copy_item_function_and_non_NULL_condition_function_returning_false_does_not_pop)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -1020,7 +981,7 @@ TEST_FUNCTION(TQUEUE_POP_after_a_POP_that_was_rejected_succeeds)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL, NULL);
+    TQUEUE(int32_t) queue = test_queue_create(1024, NULL, NULL, NULL);
     test_queue_push(queue, 42);
     test_queue_pop_rejected(queue);
 
@@ -1048,7 +1009,7 @@ TEST_FUNCTION(when_switching_the_tail_does_not_succeed_TQUEUE_POP_retries)
 {
     // arrange
     int32_t item = 45;
-    TQUEUE(int32_t) queue = test_queue_create(1024, test_push_cb, test_pop_cb, test_dispose_item, (void*)0x4242);
+    TQUEUE(int32_t) queue = test_queue_create(1024, test_copy_item, test_dispose_item, (void*)0x4242);
     test_queue_push(queue, 42);
 
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // head
@@ -1063,7 +1024,8 @@ TEST_FUNCTION(when_switching_the_tail_does_not_succeed_TQUEUE_POP_retries)
     STRICT_EXPECTED_CALL(interlocked_add_64(IGNORED_ARG, 0)); // tail
     STRICT_EXPECTED_CALL(interlocked_compare_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_POPPING, QUEUE_ENTRY_STATE_USED)); // entry_state
     STRICT_EXPECTED_CALL(interlocked_compare_exchange_64(IGNORED_ARG, 1, 0)); // tail
-    STRICT_EXPECTED_CALL(test_pop_cb((void*)0x4243, &item, IGNORED_ARG)); // tail
+    STRICT_EXPECTED_CALL(test_copy_item((void*)0x4243, &item, IGNORED_ARG)); // copy
+    STRICT_EXPECTED_CALL(test_dispose_item((void*)0x4242, IGNORED_ARG)); // dispose
     STRICT_EXPECTED_CALL(interlocked_exchange(IGNORED_ARG, QUEUE_ENTRY_STATE_NOT_USED)); // entry_state
 
     // act

--- a/tests/tqueue_ut/tqueue_ut.c
+++ b/tests/tqueue_ut/tqueue_ut.c
@@ -11,7 +11,6 @@
 #include "umock_c/umock_c.h"
 #include "umock_c/umock_c_negative_tests.h"
 #include "umock_c/umocktypes_bool.h"
-#include "umock_c/umocktypes_charptr.h"
 #include "umock_c/umocktypes_stdint.h"
 
 #define ENABLE_MOCKS
@@ -72,7 +71,6 @@ TEST_SUITE_INITIALIZE(suite_init)
 
     ASSERT_ARE_EQUAL(int, 0, umock_c_init(on_umock_c_error));
     ASSERT_ARE_EQUAL(int, 0, umocktypes_bool_register_types(), "umocktypes_bool_register_types failed");
-    ASSERT_ARE_EQUAL(int, 0, umocktypes_charptr_register_types(), "umocktypes_charptr_register_types failed");
     ASSERT_ARE_EQUAL(int, 0, umocktypes_stdint_register_types(), "umocktypes_stdint_register_types failed");
 
     REGISTER_GBALLOC_HL_GLOBAL_MOCK_HOOK();
@@ -185,7 +183,7 @@ TEST_FUNCTION(TQUEUE_CREATE_with_all_functions_NULL_succeeds)
     }
 
     // act
-    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, NULL, (void*)0x4242);
+    TQUEUE(int32_t) queue = TQUEUE_CREATE(int32_t)(1024, NULL, NULL, NULL);
 
     // assert
     ASSERT_IS_NOT_NULL(queue);
@@ -731,7 +729,7 @@ TEST_FUNCTION(TQUEUE_POP_twice_with_NULL_copy_item_function_and_NULL_condition_f
     TQUEUE_ASSIGN(int32_t)(&queue, NULL);
 }
 
-/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail == current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
+/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail >= current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
 TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_returns_QUEUE_EMPTY)
 {
     // arrange
@@ -753,7 +751,7 @@ TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_returns_QUEUE_EMPTY)
     TQUEUE_ASSIGN(int32_t)(&queue, NULL);
 }
 
-/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail == current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
+/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail >= current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
 TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_and_queue_size_1_returns_QUEUE_EMPTY)
 {
     // arrange
@@ -775,7 +773,7 @@ TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_and_queue_size_1_returns_QUEUE_EMPT
     TQUEUE_ASSIGN(int32_t)(&queue, NULL);
 }
 
-/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail == current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
+/* Tests_SRS_TQUEUE_01_035: [ If the queue is empty (current tail >= current head), TQUEUE_POP(T) shall return TQUEUE_POP_QUEUE_EMPTY. ]*/
 TEST_FUNCTION(TQUEUE_POP_when_queue_is_empty_after_a_push_and_a_pop_and_queue_size_1_returns_QUEUE_EMPTY)
 {
     // arrange


### PR DESCRIPTION
- Add TQUEUE unit tests and code
- Add TQUEUE int tests: simple int tests, chaos tests, chaos test with THANDLE
- Minor changes were needed to the algorithm due to chaos tests uncovering the issues (who said chaos tests ever catch anything!)
- Condition function was separated from the pop callback. Initial .md said they should go together but the mangling of concepts was: a) not nice and b) actually led to more complicated code