### PR TITLE
Reduce to half the time spent in hash table snapshot by using the item count maintained by the hash table to allocate the results array

### DIFF
--- a/devdoc/clds_hash_table_requirements.md
+++ b/devdoc/clds_hash_table_requirements.md
@@ -462,11 +462,7 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, C
 
 **SRS_CLDS_HASH_TABLE_42_018: [** `clds_hash_table_snapshot` shall wait for the ongoing write operations to complete. **]**
 
-**SRS_CLDS_HASH_TABLE_42_019: [** For each level of buckets maintained by the hash table: **]**
-
 **SRS_CLDS_HASH_TABLE_01_114: [** `clds_hash_table_snapshot` shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. **]**
-
- - **SRS_CLDS_HASH_TABLE_42_022: [** If the addition of the list count causes overflow then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
 **SRS_CLDS_HASH_TABLE_42_064: [** If there are no items then `clds_hash_table_snapshot` shall set `items` to `NULL` and `item_count` to `0` and return `CLDS_HASH_TABLE_SNAPSHOT_OK`. **]**
 

--- a/devdoc/clds_hash_table_requirements.md
+++ b/devdoc/clds_hash_table_requirements.md
@@ -462,11 +462,9 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, C
 
 **SRS_CLDS_HASH_TABLE_42_018: [** `clds_hash_table_snapshot` shall wait for the ongoing write operations to complete. **]**
 
-**SRS_CLDS_HASH_TABLE_42_019: [** For each bucket in the array: **]**
+**SRS_CLDS_HASH_TABLE_42_019: [** For each level of buckets maintained by the hash table: **]**
 
- - **SRS_CLDS_HASH_TABLE_42_020: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_lock_writes`. **]**
-
- - **SRS_CLDS_HASH_TABLE_42_021: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_get_count` and add to the running total. **]**
+**SRS_CLDS_HASH_TABLE_01_114: [** `clds_hash_table_snapshot` shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. **]**
 
  - **SRS_CLDS_HASH_TABLE_42_022: [** If the addition of the list count causes overflow then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
@@ -475,6 +473,8 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, C
 **SRS_CLDS_HASH_TABLE_42_023: [** `clds_hash_table_snapshot` shall allocate an array of `CLDS_HASH_TABLE_ITEM*` **]**
 
 **SRS_CLDS_HASH_TABLE_42_024: [** For each bucket in the array: **]**
+
+ - **SRS_CLDS_HASH_TABLE_42_020: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_lock_writes`. **]**
 
  - **SRS_CLDS_HASH_TABLE_42_025: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_get_count`. **]**
 

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -1118,7 +1118,7 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
 
         uint64_t temp_item_count = 0;
 
-        /* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
         BUCKET_ARRAY* current_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (current_bucket_array != NULL)
         {
@@ -1150,7 +1150,6 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
             }
             else
             {
-                bool failed = false;
                 uint64_t result_index = 0;
 
                 /* Codes_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
@@ -1163,44 +1162,43 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
                     {
                         int32_t bucket_count = interlocked_add(&current_bucket_array->bucket_count, 0);
                         int32_t i;
-                        for (i = 0; i < bucket_count; i++)
+                        bool failed = false;
+
+                        for (i = 0; (i < bucket_count) && !failed; i++)
                         {
                             if (current_bucket_array->hash_table[i] != NULL)
                             {
                                 /*Codes_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
                                 clds_sorted_list_lock_writes(current_bucket_array->hash_table[i]);
 
-                                if (!failed)
+                                /* Codes_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
+                                uint64_t list_item_count;
+                                CLDS_SORTED_LIST_GET_COUNT_RESULT count_result = clds_sorted_list_get_count(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, &list_item_count);
+                                if (count_result != CLDS_SORTED_LIST_GET_COUNT_OK)
                                 {
-                                    /* Codes_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
-                                    uint64_t list_item_count;
-                                    CLDS_SORTED_LIST_GET_COUNT_RESULT count_result = clds_sorted_list_get_count(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, &list_item_count);
-                                    if (count_result != CLDS_SORTED_LIST_GET_COUNT_OK)
+                                    /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                                    LogError("clds_sorted_list_get_count failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_COUNT_RESULT, count_result));
+                                    failed = true;
+                                }
+                                else
+                                {
+                                    if (list_item_count == 0)
                                     {
-                                        /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-                                        LogError("clds_sorted_list_get_count failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_COUNT_RESULT, count_result));
-                                        failed = true;
+                                        // skip
                                     }
                                     else
                                     {
-                                        if (list_item_count == 0)
+                                        /* Codes_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
+                                        CLDS_SORTED_LIST_GET_ALL_RESULT get_all_result = clds_sorted_list_get_all(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, list_item_count, items_to_return + result_index);
+                                        if (get_all_result != CLDS_SORTED_LIST_GET_ALL_OK)
                                         {
-                                            // skip
+                                            /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                                            LogError("clds_sorted_list_get_all failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_ALL_RESULT, get_all_result));
+                                            failed = true;
                                         }
                                         else
                                         {
-                                            /* Codes_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
-                                            CLDS_SORTED_LIST_GET_ALL_RESULT get_all_result = clds_sorted_list_get_all(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, list_item_count, items_to_return + result_index);
-                                            if (get_all_result != CLDS_SORTED_LIST_GET_ALL_OK)
-                                            {
-                                                /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-                                                LogError("clds_sorted_list_get_all failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_ALL_RESULT, get_all_result));
-                                                failed = true;
-                                            }
-                                            else
-                                            {
-                                                result_index += list_item_count;
-                                            }
+                                            result_index += list_item_count;
                                         }
                                     }
                                 }
@@ -1209,12 +1207,17 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
                                 clds_sorted_list_unlock_writes(current_bucket_array->hash_table[i]);
                             }
                         }
+
+                        if (failed)
+                        {
+                            break;
+                        }
                     }
 
                     current_bucket_array = next_bucket_array;
                 }
 
-                if (failed)
+                if (current_bucket_array != NULL)
                 {
                     result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
 

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -1117,7 +1117,6 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
         internal_lock_writes(clds_hash_table);
 
         uint64_t temp_item_count = 0;
-        bool need_to_unlock_all = false;
 
         /* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
         BUCKET_ARRAY* current_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hash_table->first_hash_table, NULL, NULL);
@@ -1125,163 +1124,118 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
         {
             BUCKET_ARRAY* next_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&current_bucket_array->next_bucket, NULL, NULL);
 
-            int64_t current_bucket_array_item_count = interlocked_add(&current_bucket_array->item_count, 0);
-
-            if (current_bucket_array_item_count + temp_item_count < temp_item_count)
-            {
-                /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-                LogError("overflow in computing total count (%" PRIu64 " + %" PRIu64 ")", temp_item_count, current_bucket_array_item_count);
-            }
-            else
-            {
-                temp_item_count += current_bucket_array_item_count;
-            }
+            temp_item_count += interlocked_add(&current_bucket_array->item_count, 0);
 
             current_bucket_array = next_bucket_array;
         }
 
-        if (current_bucket_array != NULL)
+        if (temp_item_count == 0)
         {
-            result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
+            /* Codes_SRS_CLDS_HASH_TABLE_42_064: [ If there are no items then clds_hash_table_snapshot shall set items to NULL and item_count to 0 and return CLDS_HASH_TABLE_SNAPSHOT_OK. ]*/
+            *items = NULL;
+            *item_count = 0;
+            result = CLDS_HASH_TABLE_SNAPSHOT_OK;
         }
         else
         {
-            if (temp_item_count == 0)
+            /* Codes_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
+            CLDS_SORTED_LIST_ITEM** items_to_return = malloc_2((size_t)temp_item_count, sizeof(CLDS_SORTED_LIST_ITEM*));
+
+            if (items_to_return == NULL)
             {
-                /* Codes_SRS_CLDS_HASH_TABLE_42_064: [ If there are no items then clds_hash_table_snapshot shall set items to NULL and item_count to 0 and return CLDS_HASH_TABLE_SNAPSHOT_OK. ]*/
-                *items = NULL;
-                *item_count = 0;
-                result = CLDS_HASH_TABLE_SNAPSHOT_OK;
+                /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                LogError("malloc_2((size_t)temp_item_count=%zu, sizeof(CLDS_SORTED_LIST_ITEM*)=%zu) failed for the items to return",
+                    (size_t)temp_item_count, sizeof(CLDS_SORTED_LIST_ITEM*));
+                result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
             }
             else
             {
-                /* Codes_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
-                CLDS_SORTED_LIST_ITEM** items_to_return = malloc_2((size_t)temp_item_count, sizeof(CLDS_SORTED_LIST_ITEM*));
+                bool failed = false;
+                uint64_t result_index = 0;
 
-                if (items_to_return == NULL)
+                /* Codes_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
+                current_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hash_table->first_hash_table, NULL, NULL);
+                while (current_bucket_array != NULL)
                 {
-                    /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-                    LogError("malloc_2((size_t)temp_item_count=%zu, sizeof(CLDS_SORTED_LIST_ITEM*)=%zu) failed for the items to return",
-                        (size_t)temp_item_count, sizeof(CLDS_SORTED_LIST_ITEM*));
-                    result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
-                }
-                else
-                {
-                    bool failed = false;
-                    uint64_t result_index = 0;
+                    BUCKET_ARRAY* next_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&current_bucket_array->next_bucket, NULL, NULL);
 
-                    /* Codes_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
-                    current_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hash_table->first_hash_table, NULL, NULL);
-                    while (current_bucket_array != NULL)
+                    if (interlocked_add(&current_bucket_array->item_count, 0) != 0)
                     {
-                        BUCKET_ARRAY* next_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&current_bucket_array->next_bucket, NULL, NULL);
-
-                        if (interlocked_add(&current_bucket_array->item_count, 0) != 0)
+                        int32_t bucket_count = interlocked_add(&current_bucket_array->bucket_count, 0);
+                        int32_t i;
+                        for (i = 0; i < bucket_count; i++)
                         {
-                            int32_t bucket_count = interlocked_add(&current_bucket_array->bucket_count, 0);
-                            int32_t i;
-                            for (i = 0; i < bucket_count; i++)
+                            if (current_bucket_array->hash_table[i] != NULL)
                             {
-                                if (current_bucket_array->hash_table[i] != NULL)
-                                {
-                                    /*Codes_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
-                                    clds_sorted_list_lock_writes(current_bucket_array->hash_table[i]);
+                                /*Codes_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
+                                clds_sorted_list_lock_writes(current_bucket_array->hash_table[i]);
 
-                                    if (!failed)
+                                if (!failed)
+                                {
+                                    /* Codes_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
+                                    uint64_t list_item_count;
+                                    CLDS_SORTED_LIST_GET_COUNT_RESULT count_result = clds_sorted_list_get_count(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, &list_item_count);
+                                    if (count_result != CLDS_SORTED_LIST_GET_COUNT_OK)
                                     {
-                                        /* Codes_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
-                                        uint64_t list_item_count;
-                                        CLDS_SORTED_LIST_GET_COUNT_RESULT count_result = clds_sorted_list_get_count(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, &list_item_count);
-                                        if (count_result != CLDS_SORTED_LIST_GET_COUNT_OK)
+                                        /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                                        LogError("clds_sorted_list_get_count failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_COUNT_RESULT, count_result));
+                                        failed = true;
+                                    }
+                                    else
+                                    {
+                                        if (list_item_count == 0)
                                         {
-                                            /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-                                            LogError("clds_sorted_list_get_count failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_COUNT_RESULT, count_result));
-                                            failed = true;
+                                            // skip
                                         }
                                         else
                                         {
-                                            if (list_item_count == 0)
+                                            /* Codes_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
+                                            CLDS_SORTED_LIST_GET_ALL_RESULT get_all_result = clds_sorted_list_get_all(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, list_item_count, items_to_return + result_index);
+                                            if (get_all_result != CLDS_SORTED_LIST_GET_ALL_OK)
                                             {
-                                                // skip
+                                                /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                                                LogError("clds_sorted_list_get_all failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_ALL_RESULT, get_all_result));
+                                                failed = true;
                                             }
                                             else
                                             {
-                                                /* Codes_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
-                                                CLDS_SORTED_LIST_GET_ALL_RESULT get_all_result = clds_sorted_list_get_all(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, list_item_count, items_to_return + result_index);
-                                                if (get_all_result != CLDS_SORTED_LIST_GET_ALL_OK)
-                                                {
-                                                    /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-                                                    LogError("clds_sorted_list_get_all failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_ALL_RESULT, get_all_result));
-                                                    failed = true;
-                                                }
-                                                else
-                                                {
-                                                    result_index += list_item_count;
-                                                }
+                                                result_index += list_item_count;
                                             }
                                         }
                                     }
-
-                                    /* Codes_SRS_CLDS_HASH_TABLE_42_027: [ clds_hash_table_snapshot shall call clds_sorted_list_unlock_writes. ]*/
-                                    clds_sorted_list_unlock_writes(current_bucket_array->hash_table[i]);
                                 }
+
+                                /* Codes_SRS_CLDS_HASH_TABLE_42_027: [ clds_hash_table_snapshot shall call clds_sorted_list_unlock_writes. ]*/
+                                clds_sorted_list_unlock_writes(current_bucket_array->hash_table[i]);
                             }
                         }
-
-                        current_bucket_array = next_bucket_array;
                     }
 
-                    need_to_unlock_all = false; // Unlocked
-
-                    if (failed)
-                    {
-                        result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
-
-                        for (uint64_t i = 0; i < result_index; i++)
-                        {
-                            clds_sorted_list_node_release(items_to_return[i]);
-                        }
-                        free(items_to_return);
-                    }
-                    else
-                    {
-                        /* Codes_SRS_CLDS_HASH_TABLE_42_028: [ clds_hash_table_snapshot shall store the allocated array of items in items. ]*/
-                        *items = (CLDS_HASH_TABLE_ITEM**)items_to_return;
-                        items_to_return = NULL;
-
-                        /* Codes_SRS_CLDS_HASH_TABLE_42_029: [ clds_hash_table_snapshot shall store the count of items in item_count. ]*/
-                        *item_count = result_index;
-
-                        /* Codes_SRS_CLDS_HASH_TABLE_42_031: [ clds_hash_table_snapshot shall succeed and return CLDS_HASH_TABLE_SNAPSHOT_OK. ]*/
-                        result = CLDS_HASH_TABLE_SNAPSHOT_OK;
-                    }
+                    current_bucket_array = next_bucket_array;
                 }
-            }
-        }
 
-        if (need_to_unlock_all)
-        {
-            // Unlock all the lists that have been locked so far
-            // If we only looked at part of the table, the old "current_bucket_array" is already in a cleaned up state
-            // Otherwise it is NULL and we will unlock everything
-            BUCKET_ARRAY* bucket_array_to_clean = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hash_table->first_hash_table, NULL, NULL);
-            while (bucket_array_to_clean != current_bucket_array)
-            {
-                BUCKET_ARRAY* next_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&bucket_array_to_clean->next_bucket, NULL, NULL);
-
-                if (interlocked_add(&bucket_array_to_clean->item_count, 0) != 0)
+                if (failed)
                 {
-                    int32_t bucket_count = interlocked_add(&bucket_array_to_clean->bucket_count, 0);
-                    for (int32_t i = 0; i < bucket_count; i++)
-                    {
-                        if (bucket_array_to_clean->hash_table[i] != NULL)
-                        {
-                            clds_sorted_list_unlock_writes(bucket_array_to_clean->hash_table[i]);
-                        }
-                    }
-                }
+                    result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
 
-                bucket_array_to_clean = next_bucket_array;
+                    for (uint64_t i = 0; i < result_index; i++)
+                    {
+                        clds_sorted_list_node_release(items_to_return[i]);
+                    }
+                    free(items_to_return);
+                }
+                else
+                {
+                    /* Codes_SRS_CLDS_HASH_TABLE_42_028: [ clds_hash_table_snapshot shall store the allocated array of items in items. ]*/
+                    *items = (CLDS_HASH_TABLE_ITEM**)items_to_return;
+                    items_to_return = NULL;
+
+                    /* Codes_SRS_CLDS_HASH_TABLE_42_029: [ clds_hash_table_snapshot shall store the count of items in item_count. ]*/
+                    *item_count = result_index;
+
+                    /* Codes_SRS_CLDS_HASH_TABLE_42_031: [ clds_hash_table_snapshot shall succeed and return CLDS_HASH_TABLE_SNAPSHOT_OK. ]*/
+                    result = CLDS_HASH_TABLE_SNAPSHOT_OK;
+                }
             }
         }
 

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -1119,7 +1119,7 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
         uint64_t temp_item_count = 0;
         bool need_to_unlock_all = false;
 
-        /* Codes_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
+        /* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
         BUCKET_ARRAY* current_bucket_array = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (current_bucket_array != NULL)
         {
@@ -1129,7 +1129,7 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
 
             if (current_bucket_array_item_count + temp_item_count < temp_item_count)
             {
-                /* Codes_SRS_CLDS_HASH_TABLE_42_022: [ If the addition of the list count causes overflow then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
                 LogError("overflow in computing total count (%" PRIu64 " + %" PRIu64 ")", temp_item_count, current_bucket_array_item_count);
             }
             else
@@ -1184,6 +1184,7 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
                             {
                                 if (current_bucket_array->hash_table[i] != NULL)
                                 {
+                                    /*Codes_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
                                     clds_sorted_list_lock_writes(current_bucket_array->hash_table[i]);
 
                                     if (!failed)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ if(${run_perf_tests})
     if(WIN32)
         build_test_folder(clds_hazard_pointers_thread_helper_perf) # Windows only until there is a PAL for thread local storage
     endif()
+    build_test_folder(clds_hash_table_snapshot_perf)
     add_subdirectory(clds_hash_table_perf)
     add_subdirectory(clds_singly_linked_list_perf)
     add_subdirectory(clds_sorted_list_perf)

--- a/tests/clds_hash_table_snapshot_perf/CMakeLists.txt
+++ b/tests/clds_hash_table_snapshot_perf/CMakeLists.txt
@@ -1,0 +1,24 @@
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+set(theseTestsName clds_hash_table_snapshot_perf)
+
+set(${theseTestsName}_test_files
+${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+)
+
+set(${theseTestsName}_h_files
+)
+
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+
+if("${building}" STREQUAL "exe")
+    copy_thread_notifications_lackey_outputs(${theseTestsName}_exe_${CMAKE_PROJECT_NAME} "$<TARGET_FILE_DIR:${theseTestsName}_exe_${CMAKE_PROJECT_NAME}>")
+endif()
+
+if("${building}" STREQUAL "dll")
+    copy_thread_notifications_lackey_outputs(${theseTestsName}_dll_${CMAKE_PROJECT_NAME} "$<TARGET_FILE_DIR:${theseTestsName}_exe_${CMAKE_PROJECT_NAME}>")
+endif()
+

--- a/tests/clds_hash_table_snapshot_perf/clds_hash_table_snapshot_perf.c
+++ b/tests/clds_hash_table_snapshot_perf/clds_hash_table_snapshot_perf.c
@@ -3,8 +3,6 @@
 
 #include <stdlib.h>
 #include <inttypes.h>
-#include <stdbool.h>
-#include <time.h>
 
 #include "testrunnerswitcher.h"
 
@@ -12,16 +10,10 @@
 
 #include "c_logging/logger.h"
 
-#include "c_pal/interlocked.h"
-#include "c_pal/sync.h"
-
-#include "c_pal/interlocked_hl.h"
-
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"
 
 #include "c_pal/timer.h"
-#include "c_pal/threadapi.h"
 
 #include "c_util/thread_notifications_dispatcher.h"
 
@@ -32,7 +24,6 @@
 
 TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_RESULT_VALUES);
-TEST_DEFINE_ENUM_TYPE(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_RESULT_VALUES);
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
@@ -60,7 +51,6 @@ TEST_FUNCTION_CLEANUP(method_cleanup)
 typedef struct TEST_ITEM_TAG
 {
     uint32_t key;
-    uint32_t appendix;
 } TEST_ITEM;
 
 DECLARE_HASH_TABLE_NODE_TYPE(TEST_ITEM)
@@ -118,7 +108,6 @@ TEST_FUNCTION(clds_hash_table_snapshot_perf_is_decent)
         TEST_ITEM* test_item = CLDS_HASH_TABLE_GET_VALUE(TEST_ITEM, item);
 
         test_item->key = i + 1;
-        test_item->appendix = i;
 
         int64_t insert_sequence_number;
         CLDS_HASH_TABLE_INSERT_RESULT result = clds_hash_table_insert(hash_table, clds_hazard_pointers_thread, (void*)(uintptr_t)test_item->key, (void*)item, &insert_sequence_number);

--- a/tests/clds_hash_table_snapshot_perf/clds_hash_table_snapshot_perf.c
+++ b/tests/clds_hash_table_snapshot_perf/clds_hash_table_snapshot_perf.c
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+#include <stdlib.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <time.h>
+
+#include "testrunnerswitcher.h"
+
+#include "macro_utils/macro_utils.h"
+
+#include "c_logging/logger.h"
+
+#include "c_pal/interlocked.h"
+#include "c_pal/sync.h"
+
+#include "c_pal/interlocked_hl.h"
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#include "c_pal/timer.h"
+#include "c_pal/threadapi.h"
+
+#include "c_util/thread_notifications_dispatcher.h"
+
+#include "clds/clds_hazard_pointers_thread_helper.h"
+#include "clds/clds_hazard_pointers.h"
+
+#include "clds/clds_hash_table.h"
+
+TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_RESULT_VALUES);
+TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_RESULT_VALUES);
+TEST_DEFINE_ENUM_TYPE(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_RESULT_VALUES);
+
+BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
+
+TEST_SUITE_INITIALIZE(suite_init)
+{
+    gballoc_hl_init(NULL, NULL);
+    ASSERT_ARE_EQUAL(int, 0, thread_notifications_dispatcher_init());
+}
+
+TEST_SUITE_CLEANUP(suite_cleanup)
+{
+    thread_notifications_dispatcher_deinit();
+    gballoc_hl_deinit();
+}
+
+TEST_FUNCTION_INITIALIZE(method_init)
+{
+}
+
+TEST_FUNCTION_CLEANUP(method_cleanup)
+{
+}
+
+// The item to be held in the hash table
+typedef struct TEST_ITEM_TAG
+{
+    uint32_t key;
+    uint32_t appendix;
+} TEST_ITEM;
+
+DECLARE_HASH_TABLE_NODE_TYPE(TEST_ITEM)
+
+#define TEST_ITEM_COUNT                (500000)
+
+static uint64_t test_compute_hash(void* key)
+{
+    return (uint64_t)key;
+}
+
+static int test_key_compare(void* key1, void* key2)
+{
+    int result;
+
+    if ((int64_t)key1 < (int64_t)key2)
+    {
+        result = -1;
+    }
+    else if ((int64_t)key1 > (int64_t)key2)
+    {
+        result = 1;
+    }
+    else
+    {
+        result = 0;
+    }
+
+    return result;
+}
+
+TEST_FUNCTION(clds_hash_table_snapshot_perf_is_decent)
+{
+    // The test wants to test the snapshot of a hash table that contains many items
+    // arrange
+    volatile_atomic int64_t sequence_number;
+    CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers;
+    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_pointers_thread;
+
+    clds_hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(clds_hazard_pointers);
+
+    clds_hazard_pointers_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    ASSERT_IS_NOT_NULL(clds_hazard_pointers_thread);
+
+    hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1024 * 1024, clds_hazard_pointers, &sequence_number, NULL, NULL);
+    ASSERT_IS_NOT_NULL(hash_table);
+
+    // insert some items
+    for (uint32_t i = 0; i < TEST_ITEM_COUNT; i++)
+    {
+        CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
+        ASSERT_IS_NOT_NULL(item);
+        TEST_ITEM* test_item = CLDS_HASH_TABLE_GET_VALUE(TEST_ITEM, item);
+
+        test_item->key = i + 1;
+        test_item->appendix = i;
+
+        int64_t insert_sequence_number;
+        CLDS_HASH_TABLE_INSERT_RESULT result = clds_hash_table_insert(hash_table, clds_hazard_pointers_thread, (void*)(uintptr_t)test_item->key, (void*)item, &insert_sequence_number);
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, result);
+
+        if (i % 1000 == 0)
+        {
+            LogInfo("Inserted %" PRIu32 " items", i);
+        }
+
+        // ugh, this is very old and has transfer of ownership on insert, grrr
+        // so no release here
+    }
+
+    // act
+    double start_time = timer_global_get_elapsed_ms();
+    CLDS_HASH_TABLE_ITEM** items = NULL;
+    uint64_t item_count;
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, clds_hash_table_snapshot(hash_table, clds_hazard_pointers_thread, &items, &item_count));
+    double end_time = timer_global_get_elapsed_ms();
+
+    LogInfo("Snapshot took %.02f ms", end_time - start_time);
+
+    // assert
+    ASSERT_IS_TRUE(end_time - start_time < 1000, "Snapshot took %.02f ms", end_time - start_time);
+
+    // cleanup
+    for (uint64_t i = 0; i < item_count; i++)
+    {
+        CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, items[i]);
+    }
+    free(items);
+    clds_hazard_pointers_unregister_thread(clds_hazard_pointers_thread);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(clds_hazard_pointers);
+}
+
+END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)

--- a/tests/clds_hash_table_ut/clds_hash_table_ut.c
+++ b/tests/clds_hash_table_ut/clds_hash_table_ut.c
@@ -18,7 +18,6 @@
 #include "c_pal/interlocked.h"
 
 #define ENABLE_MOCKS
-
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"
 
@@ -3683,45 +3682,6 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_
             ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_ERROR, result, "On failed call %zu", i);
         }
     }
-
-    // cleanup
-    clds_hash_table_destroy(hash_table);
-    destroy_test_context(&test_context);
-}
-
-/* Tests_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-TEST_FUNCTION(clds_hash_table_snapshot_fails_if_number_of_items_would_overflow)
-{
-    // arrange
-    CLDS_HASH_TABLE_TEST_CONTEXT test_context;
-    setup_test_context(&test_context);
-    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare_func, 1, test_context.hazard_pointers, &test_context.start_seq_no, test_skipped_seq_no_cb, NULL);
-
-    CLDS_HASH_TABLE_ITEM* item_1 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4242);
-    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x1, item_1, NULL);
-
-    CLDS_HASH_TABLE_ITEM* item_2 = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, test_item_cleanup_func, (void*)0x4243);
-    (void)clds_hash_table_insert(hash_table, test_context.hazard_pointers_thread, (void*)0x2, item_2, NULL);
-
-    umock_c_reset_all_calls();
-
-    CLDS_HASH_TABLE_ITEM** items;
-    uint64_t item_count;
-
-    uint64_t mocked_item_count_1 = UINT64_MAX / 2 + 1;
-    uint64_t mocked_item_count_2 = UINT64_MAX / 2 + 1;
-
-    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
-
-    // act
-    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, test_context.hazard_pointers_thread, &items, &item_count);
-
-    // assert
-    ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
-    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_ERROR, result);
 
     // cleanup
     clds_hash_table_destroy(hash_table);

--- a/tests/clds_hash_table_ut/clds_hash_table_ut.c
+++ b/tests/clds_hash_table_ut/clds_hash_table_ut.c
@@ -3178,9 +3178,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_null_item_count_fails)
     destroy_test_context(&test_context);
 }
 
-/* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_021: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count and add to the running total. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_064: [ If there are no items then clds_hash_table_snapshot shall set items to NULL and item_count to 0 and return CLDS_HASH_TABLE_SNAPSHOT_OK. ]. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_with_empty_table_succeeds)
 {
@@ -3208,11 +3206,10 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_empty_table_succeeds)
     destroy_test_context(&test_context);
 }
 
-/* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_021: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count and add to the running total. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_027: [ clds_hash_table_snapshot shall call clds_sorted_list_unlock_writes. ]*/
@@ -3233,11 +3230,9 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_1_item_succeeds)
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
-    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
-
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
+    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
@@ -3265,11 +3260,10 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_1_item_succeeds)
     destroy_test_context(&test_context);
 }
 
-/* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_021: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count and add to the running total. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_027: [ clds_hash_table_snapshot shall call clds_sorted_list_unlock_writes. ]*/
@@ -3298,11 +3292,9 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_succeeds)
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
-    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
-
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
+    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
@@ -3352,11 +3344,10 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_succeeds)
     destroy_test_context(&test_context);
 }
 
-/* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_021: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count and add to the running total. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_027: [ clds_hash_table_snapshot shall call clds_sorted_list_unlock_writes. ]*/
@@ -3387,16 +3378,11 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_succeeds)
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
-    for (uint32_t i = 0; i < number_of_sorted_lists; i++)
-    {
-        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
-    }
-
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
+        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
@@ -3447,11 +3433,10 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_succeeds)
     destroy_test_context(&test_context);
 }
 
-/* Tests_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
-/* Tests_SRS_CLDS_HASH_TABLE_42_021: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count and add to the running total. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_01_114: [ clds_hash_table_snapshot shall determine all the items in the hash table by summing up the item count for all bucket arrays in all levels. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
 /* Tests_SRS_CLDS_HASH_TABLE_42_027: [ clds_hash_table_snapshot shall call clds_sorted_list_unlock_writes. ]*/
@@ -3486,16 +3471,11 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_100_items_multiple_buckets_different
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
-    for (uint32_t i = 0; i < number_of_sorted_lists; i++)
-    {
-        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
-    }
-
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
+        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
@@ -3566,11 +3546,9 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_same_bucket_fails_when_unde
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
-    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
-
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
+    STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
@@ -3620,16 +3598,11 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_10_items_multiple_buckets_fails_when
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
-    for (uint32_t i = 0; i < number_of_sorted_lists; i++)
-    {
-        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
-    }
-
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
+        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
@@ -3684,16 +3657,11 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_
     CLDS_HASH_TABLE_ITEM** items;
     uint64_t item_count;
 
-    for (uint32_t i = 0; i < number_of_sorted_lists; i++)
-    {
-        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-        STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
-    }
-
     STRICT_EXPECTED_CALL(malloc_2(IGNORED_ARG, sizeof(CLDS_SORTED_LIST_ITEM*)));
 
     for (uint32_t i = 0; i < number_of_sorted_lists; i++)
     {
+        STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_get_all(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG, IGNORED_ARG));
         STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
@@ -3721,7 +3689,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_with_20_items_multiple_buckets_different_
     destroy_test_context(&test_context);
 }
 
-/* Tests_SRS_CLDS_HASH_TABLE_42_022: [ If the addition of the list count causes overflow then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
 TEST_FUNCTION(clds_hash_table_snapshot_fails_if_number_of_items_would_overflow)
 {
     // arrange
@@ -3744,13 +3712,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_fails_if_number_of_items_would_overflow)
     uint64_t mocked_item_count_2 = UINT64_MAX / 2 + 1;
 
     STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG))
-        .CopyOutArgumentBuffer_item_count(&mocked_item_count_1, sizeof(mocked_item_count_1));
-
     STRICT_EXPECTED_CALL(clds_sorted_list_lock_writes(IGNORED_ARG));
-    STRICT_EXPECTED_CALL(clds_sorted_list_get_count(IGNORED_ARG, test_context.hazard_pointers_thread, IGNORED_ARG))
-        .CopyOutArgumentBuffer_item_count(&mocked_item_count_2, sizeof(mocked_item_count_2));
-
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
     STRICT_EXPECTED_CALL(clds_sorted_list_unlock_writes(IGNORED_ARG));
 


### PR DESCRIPTION
Reduce to half the time spent in hash table snapshot by using the item count maintained by the hash table to allocate the results array