### PR TITLE
[MrBot] Switch unit tests to ENABLE_TEST_FILES_PRECOMPILED_HEADERS

### DIFF
--- a/tests/clds_hash_table_ut/CMakeLists.txt
+++ b/tests/clds_hash_table_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿#Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_hash_table_ut)
 
@@ -14,4 +14,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/clds_hash_table.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal clds_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal clds_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_hash_table_ut_pch.h")

--- a/tests/clds_hash_table_ut/clds_hash_table_ut.c
+++ b/tests/clds_hash_table_ut/clds_hash_table_ut.c
@@ -1,45 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdbool.h>
-#include <inttypes.h>
-#include <stdlib.h>
+#include "clds_hash_table_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_stdint.h"
-#include "umock_c/umocktypes_bool.h"
-#include "umock_c/umock_c_negative_tests.h"
-
-#include "c_pal/interlocked.h"
-
-#define ENABLE_MOCKS
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-#include "c_pal/thandle.h"
-
-#include "c_util/cancellation_token.h"
-
-#include "clds/clds_sorted_list.h"
-#include "clds/clds_st_hash_set.h"
-#include "clds/clds_hazard_pointers.h"
-
-#undef ENABLE_MOCKS
-#include "umock_c/umock_c_prod.h"
-
-#include "real_gballoc_hl.h"
-
-#include "../reals/real_clds_st_hash_set.h"
-#include "../reals/real_clds_hazard_pointers.h"
-#include "../reals/real_clds_sorted_list.h"
-
-#include "real_cancellation_token.h"
-
-#include "clds/clds_hash_table.h"
 
 TEST_DEFINE_ENUM_TYPE(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_RESULT_VALUES);
 IMPLEMENT_UMOCK_C_ENUM_TYPE(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_RESULT_VALUES);

--- a/tests/clds_hash_table_ut/clds_hash_table_ut_pch.h
+++ b/tests/clds_hash_table_ut/clds_hash_table_ut_pch.h
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for clds_hash_table_ut
+
+#include <stdbool.h>
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_stdint.h"
+#include "umock_c/umocktypes_bool.h"
+#include "umock_c/umock_c_negative_tests.h"
+
+#include "c_pal/interlocked.h"
+
+#define ENABLE_MOCKS
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+#include "c_pal/thandle.h"
+
+#include "c_util/cancellation_token.h"
+
+#include "clds/clds_sorted_list.h"
+#include "clds/clds_st_hash_set.h"
+#include "clds/clds_hazard_pointers.h"
+
+#undef ENABLE_MOCKS
+#include "umock_c/umock_c_prod.h"
+
+#include "real_gballoc_hl.h"
+
+#include "../reals/real_clds_st_hash_set.h"
+#include "../reals/real_clds_hazard_pointers.h"
+#include "../reals/real_clds_sorted_list.h"
+
+#include "real_cancellation_token.h"
+
+#include "clds/clds_hash_table.h"

--- a/tests/clds_hazard_pointers_thread_helper_ut/CMakeLists.txt
+++ b/tests/clds_hazard_pointers_thread_helper_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright (c) Microsoft. All rights reserved.
+﻿#Copyright (c) Microsoft. All rights reserved.
 
 set(theseTestsName clds_hazard_pointers_thread_helper_ut)
 
@@ -14,4 +14,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/clds_hazard_pointers_thread_helper.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal_umocktypes thread_notifications_lackey_dll clds_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal_umocktypes thread_notifications_lackey_dll clds_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_hazard_pointers_thread_helper_ut_pch.h")

--- a/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut.c
+++ b/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut.c
@@ -1,37 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdlib.h>
-#include <stddef.h>
+#include "clds_hazard_pointers_thread_helper_ut_pch.h"
 
-#include "windows.h"
-
-#include "macro_utils/macro_utils.h"
-
-#include "testrunnerswitcher.h"
-#include "umock_c/umock_c.h"
-#include "umock_c/umock_c_negative_tests.h"
-#include "umock_c/umocktypes.h"
-#include "umock_c/umocktypes_windows.h"
-
-#include "c_pal/interlocked.h" /*included for mocking reasons - it will prohibit creation of mocks belonging to interlocked.h - at the moment verified through int tests - this is porting legacy code, temporary solution*/
-
-#define ENABLE_MOCKS
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-
-#include "c_pal/thandle.h"
-
-#include "c_pal/ps_util.h"
-
-#include "c_util/thread_notifications_dispatcher.h"
-#include "clds/clds_hazard_pointers.h"
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-#include "real_tcall_dispatcher_thread_notification_call.h"
-
-#include "clds/clds_hazard_pointers_thread_helper.h"
 
 static DWORD default_tls_slot = 42;
 

--- a/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut_pch.h
+++ b/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut_pch.h
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for clds_hazard_pointers_thread_helper_ut
+
+#include <stdlib.h>
+#include <stddef.h>
+
+#include "windows.h"
+
+#include "macro_utils/macro_utils.h"
+
+#include "testrunnerswitcher.h"
+#include "umock_c/umock_c.h"
+#include "umock_c/umock_c_negative_tests.h"
+#include "umock_c/umocktypes.h"
+#include "umock_c/umocktypes_windows.h"
+
+#include "c_pal/interlocked.h" /*included for mocking reasons - it will prohibit creation of mocks belonging to interlocked.h - at the moment verified through int tests - this is porting legacy code, temporary solution*/
+
+#define ENABLE_MOCKS
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#include "c_pal/thandle.h"
+
+#include "c_pal/ps_util.h"
+
+#include "c_util/thread_notifications_dispatcher.h"
+#include "clds/clds_hazard_pointers.h"
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+#include "real_tcall_dispatcher_thread_notification_call.h"
+
+#include "clds/clds_hazard_pointers_thread_helper.h"

--- a/tests/clds_hazard_pointers_ut/CMakeLists.txt
+++ b/tests/clds_hazard_pointers_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿#Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_hazard_pointers_ut)
 
@@ -15,4 +15,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/clds_hazard_pointers.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals clds_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals clds_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_hazard_pointers_ut_pch.h")

--- a/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut.c
+++ b/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut.c
@@ -1,42 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdlib.h>
+#include "clds_hazard_pointers_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
 void* real_malloc(size_t size)
 {
     return real_gballoc_ll_malloc(size);
 }
-
 void real_free(void* ptr)
 {
     real_gballoc_ll_free(ptr);
 }
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_stdint.h"
-
-#include "c_pal/interlocked.h" /*included for mocking reasons - it will prohibit creation of mocks belonging to interlocked.h - at the moment verified through int tests - this is porting legacy code, temporary solution*/
-
-#include "clds/clds_hazard_pointers.h"
-
-#define ENABLE_MOCKS
-
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-
-#include "c_util/worker_thread.h"
-
-#include "clds/inactive_hp_thread_queue.h"
-
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-#include "real_inactive_hp_thread_queue.h"
 
 MU_DEFINE_ENUM_STRINGS(WORKER_THREAD_SCHEDULE_PROCESS_RESULT, WORKER_THREAD_SCHEDULE_PROCESS_RESULT_VALUES)
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)

--- a/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut_pch.h
+++ b/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut_pch.h
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for clds_hazard_pointers_ut
+
+#include <stdlib.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_stdint.h"
+
+#include "c_pal/interlocked.h" /*included for mocking reasons - it will prohibit creation of mocks belonging to interlocked.h - at the moment verified through int tests - this is porting legacy code, temporary solution*/
+
+#include "clds/clds_hazard_pointers.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#include "c_util/worker_thread.h"
+
+#include "clds/inactive_hp_thread_queue.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+#include "real_inactive_hp_thread_queue.h"

--- a/tests/clds_singly_linked_list_ut/CMakeLists.txt
+++ b/tests/clds_singly_linked_list_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿#Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_singly_linked_list_ut)
 
@@ -14,4 +14,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/clds_singly_linked_list.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals clds_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals clds_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_singly_linked_list_ut_pch.h")

--- a/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut.c
+++ b/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut.c
@@ -1,39 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdlib.h>
+#include "clds_singly_linked_list_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
 void* real_malloc(size_t size)
 {
     return real_gballoc_ll_malloc(size);
 }
-
 void real_free(void* ptr)
 {
     real_gballoc_ll_free(ptr);
 }
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_stdint.h"
-
-#define ENABLE_MOCKS
-
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-#include "clds/clds_st_hash_set.h"
-#include "clds/clds_hazard_pointers.h"
-
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-#include "../reals/real_clds_st_hash_set.h"
-#include "../reals/real_clds_hazard_pointers.h"
-
-#include "clds/clds_singly_linked_list.h"
 
 TEST_DEFINE_ENUM_TYPE(CLDS_SINGLY_LINKED_LIST_DELETE_RESULT, CLDS_SINGLY_LINKED_LIST_DELETE_RESULT_VALUES);
 IMPLEMENT_UMOCK_C_ENUM_TYPE(CLDS_SINGLY_LINKED_LIST_DELETE_RESULT, CLDS_SINGLY_LINKED_LIST_DELETE_RESULT_VALUES);

--- a/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut_pch.h
+++ b/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut_pch.h
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for clds_singly_linked_list_ut
+
+#include <stdlib.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_stdint.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+#include "clds/clds_st_hash_set.h"
+#include "clds/clds_hazard_pointers.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+#include "../reals/real_clds_st_hash_set.h"
+#include "../reals/real_clds_hazard_pointers.h"
+
+#include "clds/clds_singly_linked_list.h"

--- a/tests/clds_sorted_list_ut/CMakeLists.txt
+++ b/tests/clds_sorted_list_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿#Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_sorted_list_ut)
 
@@ -14,4 +14,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/clds_sorted_list.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals clds_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals clds_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_sorted_list_ut_pch.h")

--- a/tests/clds_sorted_list_ut/clds_sorted_list_ut.c
+++ b/tests/clds_sorted_list_ut/clds_sorted_list_ut.c
@@ -1,41 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdlib.h>
-#include <stdint.h>
+#include "clds_sorted_list_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
 void* real_malloc(size_t size)
 {
     return real_gballoc_ll_malloc(size);
 }
-
 void real_free(void* ptr)
 {
     real_gballoc_ll_free(ptr);
 }
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_stdint.h"
-#include "c_pal/interlocked.h"
-
-#define ENABLE_MOCKS
-
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-#include "clds/clds_st_hash_set.h"
-#include "clds/clds_hazard_pointers.h"
-
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-
-#include "clds/clds_sorted_list.h"
-#include "../reals/real_clds_st_hash_set.h"
-#include "../reals/real_clds_hazard_pointers.h"
 
 TEST_DEFINE_ENUM_TYPE(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_RESULT_VALUES);
 IMPLEMENT_UMOCK_C_ENUM_TYPE(CLDS_SORTED_LIST_INSERT_RESULT, CLDS_SORTED_LIST_INSERT_RESULT_VALUES);

--- a/tests/clds_sorted_list_ut/clds_sorted_list_ut_pch.h
+++ b/tests/clds_sorted_list_ut/clds_sorted_list_ut_pch.h
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for clds_sorted_list_ut
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_stdint.h"
+#include "c_pal/interlocked.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+#include "clds/clds_st_hash_set.h"
+#include "clds/clds_hazard_pointers.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+
+#include "clds/clds_sorted_list.h"
+#include "../reals/real_clds_st_hash_set.h"
+#include "../reals/real_clds_hazard_pointers.h"

--- a/tests/clds_st_hash_set_ut/CMakeLists.txt
+++ b/tests/clds_st_hash_set_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿#Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_st_hash_set_ut)
 
@@ -14,4 +14,5 @@ set(${theseTestsName}_h_files
     ../../inc/clds/clds_st_hash_set.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_st_hash_set_ut_pch.h")

--- a/tests/clds_st_hash_set_ut/clds_st_hash_set_ut.c
+++ b/tests/clds_st_hash_set_ut/clds_st_hash_set_ut.c
@@ -1,35 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdlib.h>
+#include "clds_st_hash_set_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
 void* real_malloc(size_t size)
 {
     return real_gballoc_ll_malloc(size);
 }
-
 void real_free(void* ptr)
 {
     real_gballoc_ll_free(ptr);
 }
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_stdint.h"
-
-#define ENABLE_MOCKS
-
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-
-#include "clds/clds_st_hash_set.h"
 
 TEST_DEFINE_ENUM_TYPE(CLDS_ST_HASH_SET_INSERT_RESULT, CLDS_ST_HASH_SET_INSERT_RESULT_VALUES);
 IMPLEMENT_UMOCK_C_ENUM_TYPE(CLDS_ST_HASH_SET_INSERT_RESULT, CLDS_ST_HASH_SET_INSERT_RESULT_VALUES);

--- a/tests/clds_st_hash_set_ut/clds_st_hash_set_ut_pch.h
+++ b/tests/clds_st_hash_set_ut/clds_st_hash_set_ut_pch.h
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for clds_st_hash_set_ut
+
+#include <stdlib.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_stdint.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+
+#include "clds/clds_st_hash_set.h"

--- a/tests/lock_free_set_ut/CMakeLists.txt
+++ b/tests/lock_free_set_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright (c) Microsoft. All rights reserved.
+﻿#Copyright (c) Microsoft. All rights reserved.
 
 set(theseTestsName lock_free_set_ut)
 
@@ -14,4 +14,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/lock_free_set.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/lock_free_set_ut_pch.h")

--- a/tests/lock_free_set_ut/lock_free_set_ut.c
+++ b/tests/lock_free_set_ut/lock_free_set_ut.c
@@ -1,37 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdbool.h>
-#include <stdlib.h>
+#include "lock_free_set_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
 void* real_malloc(size_t size)
 {
     return real_gballoc_ll_malloc(size);
 }
-
 void real_free(void* ptr)
 {
     real_gballoc_ll_free(ptr);
 }
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_bool.h"
-#include "c_pal/interlocked.h"
-
-#define ENABLE_MOCKS
-
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-
-#include "clds/lock_free_set.h"
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 

--- a/tests/lock_free_set_ut/lock_free_set_ut_pch.h
+++ b/tests/lock_free_set_ut/lock_free_set_ut_pch.h
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for lock_free_set_ut
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_bool.h"
+#include "c_pal/interlocked.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+
+#include "clds/lock_free_set.h"

--- a/tests/lru_cache_ut/CMakeLists.txt
+++ b/tests/lru_cache_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright (c) Microsoft. All rights reserved.
+﻿#Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName lru_cache_ut)
@@ -15,7 +15,8 @@ set(${theseTestsName}_h_files
 ../../inc/clds/lru_cache.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal clds_reals c_util c_util_reals c_pal_umocktypes)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal clds_reals c_util c_util_reals c_pal_umocktypes
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/lru_cache_ut_pch.h")
 if("${building}" STREQUAL "exe")
     copy_thread_notifications_lackey_outputs(${theseTestsName}_exe_${CMAKE_PROJECT_NAME} $<TARGET_FILE_DIR:${theseTestsName}_exe_${CMAKE_PROJECT_NAME}>)
 endif()

--- a/tests/lru_cache_ut/lru_cache_ut.c
+++ b/tests/lru_cache_ut/lru_cache_ut.c
@@ -1,49 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include <inttypes.h>
-#include <stdlib.h>
+#include "lru_cache_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_stdint.h"
-#include "umock_c/umock_c_negative_tests.h"
-
-// TODO: This should go back to mocks: 
-// Task 25774695: Fix mocking for interlocked when using reals hazard pointers
-#include "c_pal/interlocked.h"
-
-#define ENABLE_MOCKS
-
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-#include "c_pal/srw_lock_ll.h"
-
-#include "c_util/doublylinkedlist.h"
-
-#include "clds/clds_hash_table.h"
-#include "clds/clds_hazard_pointers.h"
-#include "clds/clds_hazard_pointers_thread_helper.h"
-
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-#include "real_srw_lock_ll.h"
-#include "real_doublylinkedlist.h"
-
-#include "../reals/real_interlocked.h"
-#include "../reals/real_clds_hash_table.h"
-#include "../reals/real_clds_hazard_pointers.h"
-#include "../reals/real_clds_hazard_pointers_thread_helper.h"
-
-#include "real_thread_notifications_dispatcher.h"
-
-
-#include "clds/lru_cache.h"
 
 TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_RESULT_VALUES);
 IMPLEMENT_UMOCK_C_ENUM_TYPE(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_RESULT_VALUES);

--- a/tests/lru_cache_ut/lru_cache_ut_pch.h
+++ b/tests/lru_cache_ut/lru_cache_ut_pch.h
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Precompiled header for lru_cache_ut
+
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_stdint.h"
+#include "umock_c/umock_c_negative_tests.h"
+
+// TODO: This should go back to mocks: 
+// Task 25774695: Fix mocking for interlocked when using reals hazard pointers
+#include "c_pal/interlocked.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+#include "c_pal/srw_lock_ll.h"
+
+#include "c_util/doublylinkedlist.h"
+
+#include "clds/clds_hash_table.h"
+#include "clds/clds_hazard_pointers.h"
+#include "clds/clds_hazard_pointers_thread_helper.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+#include "real_srw_lock_ll.h"
+#include "real_doublylinkedlist.h"
+
+#include "../reals/real_interlocked.h"
+#include "../reals/real_clds_hash_table.h"
+#include "../reals/real_clds_hazard_pointers.h"
+#include "../reals/real_clds_hazard_pointers_thread_helper.h"
+
+#include "real_thread_notifications_dispatcher.h"
+
+
+#include "clds/lru_cache.h"

--- a/tests/mpsc_lock_free_queue_ut/CMakeLists.txt
+++ b/tests/mpsc_lock_free_queue_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright (c) Microsoft. All rights reserved.
+﻿#Copyright (c) Microsoft. All rights reserved.
 
 set(theseTestsName mpsc_lock_free_queue_ut)
 
@@ -14,4 +14,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/mpsc_lock_free_queue.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/mpsc_lock_free_queue_ut_pch.h")

--- a/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut.c
+++ b/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut.c
@@ -1,36 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
-#include <stdbool.h>
-#include <stdlib.h>
+#include "mpsc_lock_free_queue_ut_pch.h"
 
-#include "macro_utils/macro_utils.h"
-#include "testrunnerswitcher.h"
-
-#include "real_gballoc_ll.h"
 void* real_malloc(size_t size)
 {
     return real_gballoc_ll_malloc(size);
 }
-
 void real_free(void* ptr)
 {
     real_gballoc_ll_free(ptr);
 }
-
-#include "umock_c/umock_c.h"
-#include "umock_c/umocktypes_bool.h"
-
-#define ENABLE_MOCKS
-
-#include "c_pal/gballoc_hl.h"
-#include "c_pal/gballoc_hl_redirect.h"
-
-#undef ENABLE_MOCKS
-
-#include "real_gballoc_hl.h"
-
-#include "clds/mpsc_lock_free_queue.h"
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 

--- a/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut_pch.h
+++ b/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut_pch.h
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+// Precompiled header for mpsc_lock_free_queue_ut
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "macro_utils/macro_utils.h"
+#include "testrunnerswitcher.h"
+
+#include "real_gballoc_ll.h"
+
+
+#include "umock_c/umock_c.h"
+#include "umock_c/umocktypes_bool.h"
+
+#define ENABLE_MOCKS
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+
+#undef ENABLE_MOCKS
+
+#include "real_gballoc_hl.h"
+
+#include "clds/mpsc_lock_free_queue.h"

--- a/tests/reals_ut/CMakeLists.txt
+++ b/tests/reals_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-#Copyright (c) Microsoft. All rights reserved.
+﻿#Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_reals_ut)
@@ -13,7 +13,8 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals clds_reals)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals clds_reals
+    ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_reals_ut_pch.h")
 
 if(WIN32)
 if("${building}" STREQUAL "exe")

--- a/tests/reals_ut/clds_reals_ut.c
+++ b/tests/reals_ut/clds_reals_ut.c
@@ -1,36 +1,8 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#include "testrunnerswitcher.h"
-#include "umock_c/umock_c.h"
+#include "clds_reals_ut_pch.h"
 
-#define ENABLE_MOCKS
-
-#if WIN32
-#include "clds/clds_hazard_pointers.h"
-#include "clds/clds_hazard_pointers_thread_helper.h"
-#endif
-#include "clds/clds_hash_table.h"
-#include "clds/clds_singly_linked_list.h"
-#include "clds/clds_sorted_list.h"
-#include "clds/clds_st_hash_set.h"
-#include "clds/lock_free_set.h"
-#include "clds/mpsc_lock_free_queue.h"
-#include "clds/inactive_hp_thread_queue.h"
-
-#undef ENABLE_MOCKS
-
-#if WIN32
-#include "../tests/reals/real_clds_hazard_pointers.h"
-#include "../tests/reals/real_clds_hazard_pointers_thread_helper.h"
-#endif
-#include "../tests/reals/real_clds_hash_table.h"
-#include "../tests/reals/real_clds_singly_linked_list.h"
-#include "../tests/reals/real_clds_sorted_list.h"
-#include "../tests/reals/real_clds_st_hash_set.h"
-#include "../tests/reals/real_lock_free_set.h"
-#include "../tests/reals/real_mpsc_lock_free_queue.h"
-#include "../tests/reals/real_inactive_hp_thread_queue.h"
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 

--- a/tests/reals_ut/clds_reals_ut_pch.h
+++ b/tests/reals_ut/clds_reals_ut_pch.h
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Precompiled header for clds_reals_ut
+
+#include "testrunnerswitcher.h"
+#include "umock_c/umock_c.h"
+
+#define ENABLE_MOCKS
+
+#if WIN32
+#include "clds/clds_hazard_pointers.h"
+#include "clds/clds_hazard_pointers_thread_helper.h"
+#endif
+#include "clds/clds_hash_table.h"
+#include "clds/clds_singly_linked_list.h"
+#include "clds/clds_sorted_list.h"
+#include "clds/clds_st_hash_set.h"
+#include "clds/lock_free_set.h"
+#include "clds/mpsc_lock_free_queue.h"
+#include "clds/inactive_hp_thread_queue.h"
+
+#undef ENABLE_MOCKS
+
+#if WIN32
+#include "../tests/reals/real_clds_hazard_pointers.h"
+#include "../tests/reals/real_clds_hazard_pointers_thread_helper.h"
+#endif
+#include "../tests/reals/real_clds_hash_table.h"
+#include "../tests/reals/real_clds_singly_linked_list.h"
+#include "../tests/reals/real_clds_sorted_list.h"
+#include "../tests/reals/real_clds_st_hash_set.h"
+#include "../tests/reals/real_lock_free_set.h"
+#include "../tests/reals/real_mpsc_lock_free_queue.h"
+#include "../tests/reals/real_inactive_hp_thread_queue.h"


### PR DESCRIPTION
Migrate unit tests from MOCK_PRECOMPILE_HEADERS to ENABLE_TEST_FILES_PRECOMPILED_HEADERS option. Updates c-testrunnerswitcher dependency and creates PCH headers for all unit test projects.