### PR TITLE
Convert all tests to use TIMED_TEST_SUITE_INITIALIZE/CLEANUP

### DIFF
--- a/tests/clds_hash_table_int/CMakeLists.txt
+++ b/tests/clds_hash_table_int/CMakeLists.txt
@@ -12,4 +12,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal clds)

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -27,6 +27,7 @@
 
 #include "c_util/cancellation_token.h"
 #include "c_pal/tqueue.h"
+#include "c_pal/timed_test_suite.h"
 
 #include "clds/clds_hazard_pointers.h"
 #include "clds/clds_hash_table.h"
@@ -567,12 +568,12 @@ MU_DEFINE_ENUM_STRINGS_WITHOUT_INVALID(CHAOS_TEST_ACTION, CHAOS_TEST_ACTION_VALU
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     gballoc_hl_init(NULL, NULL);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     gballoc_hl_deinit();
 }

--- a/tests/clds_hash_table_snapshot_perf/CMakeLists.txt
+++ b/tests/clds_hash_table_snapshot_perf/CMakeLists.txt
@@ -12,7 +12,7 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal clds)
 
 if("${building}" STREQUAL "exe")
     copy_thread_notifications_lackey_outputs(${theseTestsName}_exe_${CMAKE_PROJECT_NAME} "$<TARGET_FILE_DIR:${theseTestsName}_exe_${CMAKE_PROJECT_NAME}>")

--- a/tests/clds_hash_table_snapshot_perf/clds_hash_table_snapshot_perf.c
+++ b/tests/clds_hash_table_snapshot_perf/clds_hash_table_snapshot_perf.c
@@ -27,13 +27,13 @@ TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     gballoc_hl_init(NULL, NULL);
     ASSERT_ARE_EQUAL(int, 0, thread_notifications_dispatcher_init());
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     thread_notifications_dispatcher_deinit();
     gballoc_hl_deinit();

--- a/tests/clds_hash_table_ut/clds_hash_table_ut.c
+++ b/tests/clds_hash_table_ut/clds_hash_table_ut.c
@@ -80,7 +80,7 @@ DECLARE_HASH_TABLE_NODE_TYPE(TEST_ITEM)
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, real_gballoc_hl_init(NULL, NULL));
 
@@ -128,7 +128,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     ASSERT_ARE_EQUAL(int, 0, umock_c_negative_tests_init());
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     umock_c_negative_tests_deinit();
     umock_c_deinit();

--- a/tests/clds_hash_table_ut/clds_hash_table_ut_pch.h
+++ b/tests/clds_hash_table_ut/clds_hash_table_ut_pch.h
@@ -22,6 +22,8 @@
 
 #include "c_pal/interlocked.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"

--- a/tests/clds_hash_table_with_memory_limit_int/CMakeLists.txt
+++ b/tests/clds_hash_table_with_memory_limit_int/CMakeLists.txt
@@ -12,4 +12,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal clds)

--- a/tests/clds_hash_table_with_memory_limit_int/clds_hash_table_with_memory_limit_int.c
+++ b/tests/clds_hash_table_with_memory_limit_int/clds_hash_table_with_memory_limit_int.c
@@ -19,6 +19,7 @@
 #include "c_pal/gballoc_hl_redirect.h"
 #include "c_pal/thandle.h"
 #include "c_pal/job_object_helper.h"
+#include "c_pal/timed_test_suite.h"
 
 #include "clds/clds_hazard_pointers.h"
 #include "clds/clds_hash_table.h"
@@ -68,12 +69,12 @@ static void test_skipped_seq_no_ignore(void* context, int64_t skipped_sequence_n
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     gballoc_hl_init(NULL, NULL);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     gballoc_hl_deinit();
 }

--- a/tests/clds_hazard_pointers_thread_helper_perf/CMakeLists.txt
+++ b/tests/clds_hazard_pointers_thread_helper_perf/CMakeLists.txt
@@ -12,7 +12,7 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal clds)
 
 if("${building}" STREQUAL "exe")
     copy_thread_notifications_lackey_outputs(${theseTestsName}_exe_${CMAKE_PROJECT_NAME} "$<TARGET_FILE_DIR:${theseTestsName}_exe_${CMAKE_PROJECT_NAME}>")

--- a/tests/clds_hazard_pointers_thread_helper_perf/clds_hazard_pointers_thread_helper_perf.c
+++ b/tests/clds_hazard_pointers_thread_helper_perf/clds_hazard_pointers_thread_helper_perf.c
@@ -37,13 +37,13 @@ TEST_DEFINE_ENUM_TYPE(INTERLOCKED_HL_RESULT, INTERLOCKED_HL_RESULT_VALUES);
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     gballoc_hl_init(NULL, NULL);
     ASSERT_ARE_EQUAL(int, 0, thread_notifications_dispatcher_init());
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     thread_notifications_dispatcher_deinit();
     gballoc_hl_deinit();

--- a/tests/clds_hazard_pointers_thread_helper_ut/CMakeLists.txt
+++ b/tests/clds_hazard_pointers_thread_helper_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿#Copyright (c) Microsoft. All rights reserved.
+#Copyright (c) Microsoft. All rights reserved.
 
 set(theseTestsName clds_hazard_pointers_thread_helper_ut)
 
@@ -14,5 +14,5 @@ set(${theseTestsName}_h_files
 ../../inc/clds/clds_hazard_pointers_thread_helper.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals c_pal_umocktypes thread_notifications_lackey_dll clds_reals
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals c_pal_umocktypes thread_notifications_lackey_dll clds_reals
     ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_hazard_pointers_thread_helper_ut_pch.h")

--- a/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut.c
+++ b/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut.c
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
 #include "clds_hazard_pointers_thread_helper_ut_pch.h"
@@ -99,7 +99,7 @@ static TCALL_DISPATCHER(THREAD_NOTIFICATION_CALL) hook_thread_notifications_disp
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, real_gballoc_hl_init(NULL, NULL));
 
@@ -129,7 +129,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCKC_PAIRED_CREATE_DESTROY_CALLS(mocked_TlsAlloc, mocked_TlsFree);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     TCALL_DISPATCHER_ASSIGN(real_THREAD_NOTIFICATION_CALL)(&g.thread_notification_call_dispatcher, NULL);
 

--- a/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut_pch.h
+++ b/tests/clds_hazard_pointers_thread_helper_ut/clds_hazard_pointers_thread_helper_ut_pch.h
@@ -21,6 +21,8 @@
 
 #include "c_pal/interlocked.h" /*included for mocking reasons - it will prohibit creation of mocks belonging to interlocked.h - at the moment verified through int tests - this is porting legacy code, temporary solution*/
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"

--- a/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut.c
+++ b/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut.c
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
 #include "clds_hazard_pointers_ut_pch.h"
@@ -27,7 +27,7 @@ static WORKER_THREAD_HANDLE test_worker_thread = (WORKER_THREAD_HANDLE)0x4242;
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, real_gballoc_hl_init(NULL, NULL));
 
@@ -47,7 +47,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCK_ALIAS_TYPE(WORKER_THREAD_HANDLE, void*);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     umock_c_deinit();
 

--- a/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut_pch.h
+++ b/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut_pch.h
@@ -20,6 +20,8 @@
 
 #include "clds/clds_hazard_pointers.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #include "c_pal/gballoc_hl.h"

--- a/tests/clds_singly_linked_list_int/CMakeLists.txt
+++ b/tests/clds_singly_linked_list_int/CMakeLists.txt
@@ -12,4 +12,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal clds)

--- a/tests/clds_singly_linked_list_int/clds_singly_linked_list_int.c
+++ b/tests/clds_singly_linked_list_int/clds_singly_linked_list_int.c
@@ -17,6 +17,7 @@
 #include "c_pal/gballoc_hl_redirect.h"
 #include "c_pal/interlocked.h"
 #include "c_pal/threadapi.h"
+#include "c_pal/timed_test_suite.h"
 
 #include "clds/clds_hazard_pointers.h"
 
@@ -91,12 +92,12 @@ MU_DEFINE_ENUM_WITHOUT_INVALID(CHAOS_TEST_ACTION, CHAOS_TEST_ACTION_VALUES);
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, gballoc_hl_init(NULL, NULL));
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     gballoc_hl_deinit();
 }

--- a/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut.c
+++ b/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut.c
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
 #include "clds_singly_linked_list_ut_pch.h"
@@ -57,7 +57,7 @@ DECLARE_SINGLY_LINKED_LIST_NODE_TYPE(TEST_ITEM)
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     int result;
 
@@ -83,7 +83,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCK_ALIAS_TYPE(CLDS_ST_HASH_SET_KEY_COMPARE_FUNC, void*);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     umock_c_deinit();
 

--- a/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut_pch.h
+++ b/tests/clds_singly_linked_list_ut/clds_singly_linked_list_ut_pch.h
@@ -16,6 +16,8 @@
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_stdint.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #include "c_pal/gballoc_hl.h"

--- a/tests/clds_sorted_list_int/CMakeLists.txt
+++ b/tests/clds_sorted_list_int/CMakeLists.txt
@@ -12,4 +12,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal clds)

--- a/tests/clds_sorted_list_int/clds_sorted_list_int.c
+++ b/tests/clds_sorted_list_int/clds_sorted_list_int.c
@@ -21,6 +21,7 @@
 #include "c_pal/uuid.h"
 
 #include "c_pal/interlocked_hl.h"
+#include "c_pal/timed_test_suite.h"
 #include "c_util/uuid_string.h"
 
 #include "clds/clds_hazard_pointers.h"
@@ -201,12 +202,12 @@ MU_DEFINE_ENUM_WITHOUT_INVALID(CHAOS_TEST_ACTION, CHAOS_TEST_ACTION_VALUES);
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, gballoc_hl_init(NULL, NULL));
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     gballoc_hl_deinit();
 }

--- a/tests/clds_sorted_list_ut/clds_sorted_list_ut.c
+++ b/tests/clds_sorted_list_ut/clds_sorted_list_ut.c
@@ -80,7 +80,7 @@ static int test_key_compare(void* context, void* key1, void* key2)
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     int result;
 
@@ -113,7 +113,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_UMOCK_ALIAS_TYPE(CLDS_ST_HASH_SET_KEY_COMPARE_FUNC, void*);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     umock_c_deinit();
 

--- a/tests/clds_sorted_list_ut/clds_sorted_list_ut_pch.h
+++ b/tests/clds_sorted_list_ut/clds_sorted_list_ut_pch.h
@@ -18,6 +18,8 @@
 #include "umock_c/umocktypes_stdint.h"
 #include "c_pal/interlocked.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #include "c_pal/gballoc_hl.h"

--- a/tests/clds_st_hash_set_ut/CMakeLists.txt
+++ b/tests/clds_st_hash_set_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_st_hash_set_ut)
 
@@ -14,5 +14,5 @@ set(${theseTestsName}_h_files
     ../../inc/clds/clds_st_hash_set.h
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals
     ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_st_hash_set_ut_pch.h")

--- a/tests/clds_st_hash_set_ut/clds_st_hash_set_ut.c
+++ b/tests/clds_st_hash_set_ut/clds_st_hash_set_ut.c
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
 #include "clds_st_hash_set_ut_pch.h"
@@ -35,7 +35,7 @@ MOCK_FUNCTION_END(0)
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     int result;
 
@@ -56,7 +56,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_TYPE(CLDS_ST_HASH_SET_FIND_RESULT, CLDS_ST_HASH_SET_FIND_RESULT);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     umock_c_deinit();
 

--- a/tests/clds_st_hash_set_ut/clds_st_hash_set_ut_pch.h
+++ b/tests/clds_st_hash_set_ut/clds_st_hash_set_ut_pch.h
@@ -16,6 +16,8 @@
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_stdint.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #include "c_pal/gballoc_hl.h"

--- a/tests/lock_free_set_int/lock_free_set_int.c
+++ b/tests/lock_free_set_int/lock_free_set_int.c
@@ -9,6 +9,7 @@
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"
 #include "c_pal/threadapi.h"
+#include "c_pal/timed_test_suite.h"
 
 #include "clds/lock_free_set.h"
 
@@ -55,12 +56,12 @@ TEST_DEFINE_ENUM_TYPE(THREADAPI_RESULT, THREADAPI_RESULT_VALUES);
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, gballoc_hl_init(NULL, NULL));
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     gballoc_hl_deinit();
 }

--- a/tests/lock_free_set_ut/lock_free_set_ut.c
+++ b/tests/lock_free_set_ut/lock_free_set_ut.c
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
 #include "lock_free_set_ut_pch.h"
@@ -24,7 +24,7 @@ MOCK_FUNCTION_END()
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     int result;
 
@@ -38,7 +38,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_GBALLOC_HL_GLOBAL_MOCK_HOOK();
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     umock_c_deinit();
 

--- a/tests/lock_free_set_ut/lock_free_set_ut_pch.h
+++ b/tests/lock_free_set_ut/lock_free_set_ut_pch.h
@@ -18,6 +18,8 @@
 #include "umock_c/umocktypes_bool.h"
 #include "c_pal/interlocked.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #include "c_pal/gballoc_hl.h"

--- a/tests/lru_cache_int/CMakeLists.txt
+++ b/tests/lru_cache_int/CMakeLists.txt
@@ -12,7 +12,7 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal clds)
 
 if("${building}" STREQUAL "exe")
     copy_thread_notifications_lackey_outputs(${theseTestsName}_exe_${CMAKE_PROJECT_NAME} "$<TARGET_FILE_DIR:${theseTestsName}_exe_${CMAKE_PROJECT_NAME}>")

--- a/tests/lru_cache_int/lru_cache_int.c
+++ b/tests/lru_cache_int/lru_cache_int.c
@@ -21,6 +21,7 @@
 #include "c_pal/sync.h"
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"
+#include "c_pal/timed_test_suite.h"
 
 #include "clds/clds_hazard_pointers.h"
 #include "clds/clds_hash_table.h"
@@ -171,12 +172,12 @@ static int key_compare(void* key_1, void* key_2)
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, gballoc_hl_init(NULL, NULL));
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     gballoc_hl_deinit();
 }

--- a/tests/lru_cache_ut/lru_cache_ut.c
+++ b/tests/lru_cache_ut/lru_cache_ut.c
@@ -85,7 +85,7 @@ MOCK_FUNCTION_END()
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, real_gballoc_hl_init(NULL, NULL));
 
@@ -137,7 +137,7 @@ TEST_SUITE_INITIALIZE(suite_init)
 
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     real_clds_hazard_pointers_thread_helper_destroy(test_clds_hazard_pointers_thread_helper);
     real_clds_hazard_pointers_destroy(test_clds_hazard_pointers);

--- a/tests/lru_cache_ut/lru_cache_ut_pch.h
+++ b/tests/lru_cache_ut/lru_cache_ut_pch.h
@@ -22,6 +22,8 @@
 // Task 25774695: Fix mocking for interlocked when using reals hazard pointers
 #include "c_pal/interlocked.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #include "c_pal/gballoc_hl.h"

--- a/tests/mpsc_lock_free_queue_int/CMakeLists.txt
+++ b/tests/mpsc_lock_free_queue_int/CMakeLists.txt
@@ -13,4 +13,4 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_util)
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_util)

--- a/tests/mpsc_lock_free_queue_int/mpsc_lock_free_queue_int.c
+++ b/tests/mpsc_lock_free_queue_int/mpsc_lock_free_queue_int.c
@@ -9,6 +9,7 @@
 #include "c_pal/gballoc_hl.h"
 #include "c_pal/gballoc_hl_redirect.h"
 #include "c_pal/threadapi.h"
+#include "c_pal/timed_test_suite.h"
 
 #include "clds/mpsc_lock_free_queue.h"
 
@@ -69,12 +70,12 @@ TEST_DEFINE_ENUM_TYPE(THREADAPI_RESULT, THREADAPI_RESULT_VALUES);
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     ASSERT_ARE_EQUAL(int, 0, gballoc_hl_init(NULL, NULL));
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     gballoc_hl_deinit();
 }

--- a/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut.c
+++ b/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut.c
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.See LICENSE file in the project root for full license information.
 
 #include "mpsc_lock_free_queue_ut_pch.h"
@@ -21,7 +21,7 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
-TEST_SUITE_INITIALIZE(suite_init)
+TIMED_TEST_SUITE_INITIALIZE(suite_init, TIMED_TEST_DEFAULT_TIMEOUT_MS)
 {
     int result;
 
@@ -36,7 +36,7 @@ TEST_SUITE_INITIALIZE(suite_init)
     REGISTER_GLOBAL_MOCK_HOOK(free, real_free);
 }
 
-TEST_SUITE_CLEANUP(suite_cleanup)
+TIMED_TEST_SUITE_CLEANUP(suite_cleanup)
 {
     umock_c_deinit();
 

--- a/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut_pch.h
+++ b/tests/mpsc_lock_free_queue_ut/mpsc_lock_free_queue_ut_pch.h
@@ -17,6 +17,8 @@
 #include "umock_c/umock_c.h"
 #include "umock_c/umocktypes_bool.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #include "c_pal/gballoc_hl.h"

--- a/tests/reals_ut/CMakeLists.txt
+++ b/tests/reals_ut/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿#Copyright (c) Microsoft. All rights reserved.
+#Copyright (c) Microsoft. All rights reserved.
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 set(theseTestsName clds_reals_ut)
@@ -13,7 +13,7 @@ set(${theseTestsName}_c_files
 set(${theseTestsName}_h_files
 )
 
-build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal_reals clds_reals
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS c_pal c_pal_reals clds_reals
     ENABLE_TEST_FILES_PRECOMPILED_HEADERS "${CMAKE_CURRENT_LIST_DIR}/clds_reals_ut_pch.h")
 
 if(WIN32)

--- a/tests/reals_ut/clds_reals_ut_pch.h
+++ b/tests/reals_ut/clds_reals_ut_pch.h
@@ -9,6 +9,8 @@
 #include "testrunnerswitcher.h"
 #include "umock_c/umock_c.h"
 
+#include "c_pal/timed_test_suite.h"
+
 #include "umock_c/umock_c_ENABLE_MOCKS.h" // ============================== ENABLE_MOCKS
 
 #if WIN32


### PR DESCRIPTION
Converts all 18 test files from TEST_SUITE_INITIALIZE/CLEANUP to TIMED_TEST_SUITE_INITIALIZE/CLEANUP. Adds c_pal/timed_test_suite.h to PCH and int test files.

Prerequisites:
- https://github.com/Azure/c-testrunnerswitcher/pull/287
- https://github.com/Azure/c-pal/pull/545
