### PR TITLE
Enable arm64_max_stage ALL for ARM64 CI leg in devops_gated.yml

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -31,6 +31,7 @@ jobs:
     ARCH_TYPE_VALUES: ["x64", "ARM64"]
     pool_name_x64: ${{ parameters.pool_name_windows_x64 }}
     pool_name_arm64: ${{ parameters.pool_name_windows_arm64 }}
+    arm64_max_stage: ALL
 
 - template: /pipeline_templates/run_master_check.yml@c_build_tools
   parameters:


### PR DESCRIPTION
Opt the clds ARM64 test leg into running every registered test category (unit, int, perf, e2e) by passing arm64_max_stage: ALL to build_all_flavors.yml, matching c-util, ctest and sf-c-util. The pinned c_build_tools ref already exposes this parameter.