### PR TITLE
[MrBot] Fix hazard pointers reclaim_list leak on thread unregister (Task #36604983) [Ready]

### DIFF
--- a/devdoc/clds_hazard_pointers_requirements.md
+++ b/devdoc/clds_hazard_pointers_requirements.md
@@ -42,7 +42,7 @@ MOCKABLE_FUNCTION(, void, clds_hazard_pointers_destroy, CLDS_HAZARD_POINTERS_HAN
 
 **SRS_CLDS_HAZARD_POINTERS_01_005: [** If `clds_hazard_pointers` is NULL, `clds_hazard_pointers_destroy` shall return. **]**
 
-**SRS_CLDS_HAZARD_POINTERS_01_028: [** `clds_hazard_pointers_destroy` shall reclaim all entries remaining on the global pending reclaim list. **]**
+**SRS_CLDS_HAZARD_POINTERS_42_003: [** `clds_hazard_pointers_destroy` shall reclaim all entries remaining on the global pending reclaim list. **]**
 
 ### clds_hazard_pointers_register_thread
 
@@ -64,7 +64,7 @@ MOCKABLE_FUNCTION(, void, clds_hazard_pointers_unregister_thread, CLDS_HAZARD_PO
 
 **SRS_CLDS_HAZARD_POINTERS_01_009: [** `clds_hazard_pointers_unregister_thread` shall unregister the thread identified by `clds_hazard_pointers_thread` from its associated hazard pointers instance. **]**
 
-**SRS_CLDS_HAZARD_POINTERS_01_025: [** `clds_hazard_pointers_unregister_thread` shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. **]**
+**SRS_CLDS_HAZARD_POINTERS_42_001: [** `clds_hazard_pointers_unregister_thread` shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. **]**
 
 **SRS_CLDS_HAZARD_POINTERS_01_010: [** If `clds_hazard_pointers_thread` is NULL, `clds_hazard_pointers_unregister_thread` shall return. **]**
 
@@ -106,7 +106,7 @@ MOCKABLE_FUNCTION(, void, clds_hazard_pointers_reclaim, CLDS_HAZARD_POINTERS_THR
 
 **SRS_CLDS_HAZARD_POINTERS_01_020: [** If no thread has acquired a hazard pointer for `node`, `reclaim_func` shall be called for `node` to reclaim it. **]**
 
-**SRS_CLDS_HAZARD_POINTERS_01_027: [** When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. **]**
+**SRS_CLDS_HAZARD_POINTERS_42_002: [** When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. **]**
 
 ### clds_hazard_pointers_set_reclaim_threshold
 

--- a/devdoc/clds_hazard_pointers_requirements.md
+++ b/devdoc/clds_hazard_pointers_requirements.md
@@ -42,6 +42,8 @@ MOCKABLE_FUNCTION(, void, clds_hazard_pointers_destroy, CLDS_HAZARD_POINTERS_HAN
 
 **SRS_CLDS_HAZARD_POINTERS_01_005: [** If `clds_hazard_pointers` is NULL, `clds_hazard_pointers_destroy` shall return. **]**
 
+**SRS_CLDS_HAZARD_POINTERS_01_028: [** `clds_hazard_pointers_destroy` shall reclaim all entries remaining on the global pending reclaim list. **]**
+
 ### clds_hazard_pointers_register_thread
 
 ```c
@@ -61,6 +63,8 @@ MOCKABLE_FUNCTION(, void, clds_hazard_pointers_unregister_thread, CLDS_HAZARD_PO
 ```
 
 **SRS_CLDS_HAZARD_POINTERS_01_009: [** `clds_hazard_pointers_unregister_thread` shall unregister the thread identified by `clds_hazard_pointers_thread` from its associated hazard pointers instance. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_01_025: [** `clds_hazard_pointers_unregister_thread` shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. **]**
 
 **SRS_CLDS_HAZARD_POINTERS_01_010: [** If `clds_hazard_pointers_thread` is NULL, `clds_hazard_pointers_unregister_thread` shall return. **]**
 
@@ -101,6 +105,8 @@ MOCKABLE_FUNCTION(, void, clds_hazard_pointers_reclaim, CLDS_HAZARD_POINTERS_THR
 **SRS_CLDS_HAZARD_POINTERS_01_019: [** If any other thread has acquired a hazard pointer for `node`, the `reclaim_func` shall not be called for `node`. **]**
 
 **SRS_CLDS_HAZARD_POINTERS_01_020: [** If no thread has acquired a hazard pointer for `node`, `reclaim_func` shall be called for `node` to reclaim it. **]**
+
+**SRS_CLDS_HAZARD_POINTERS_01_027: [** When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. **]**
 
 ### clds_hazard_pointers_set_reclaim_threshold
 

--- a/src/clds_hazard_pointers.c
+++ b/src/clds_hazard_pointers.c
@@ -277,7 +277,7 @@ static void internal_reclaim(CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_poin
             // unregistered while their retired node was still protected by another thread).
             // Detach the whole list atomically, reclaim every entry whose node is no longer
             // held and re-push the ones that are still protected.
-            /*Codes_SRS_CLDS_HAZARD_POINTERS_01_027: [ internal_reclaim shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. ]*/
+            /*Codes_SRS_CLDS_HAZARD_POINTERS_42_002: [ When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. ]*/
             CLDS_RECLAIM_LIST_ENTRY* pending_entry = interlocked_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL);
             CLDS_RECLAIM_LIST_ENTRY* still_held_first = NULL;
             CLDS_RECLAIM_LIST_ENTRY* still_held_last = NULL;
@@ -486,7 +486,7 @@ void clds_hazard_pointers_destroy(CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointe
             clds_hazard_pointers_thread = next_clds_hazard_pointers_thread;
         }
 
-        /*Codes_SRS_CLDS_HAZARD_POINTERS_01_028: [ clds_hazard_pointers_destroy shall reclaim all entries remaining on the global pending reclaim list. ]*/
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_42_003: [ clds_hazard_pointers_destroy shall reclaim all entries remaining on the global pending reclaim list. ]*/
         // all threads are gone now, so no hazard pointer can be held: drain whatever was handed off
         // by unregistered threads and never reclaimed.
         CLDS_RECLAIM_LIST_ENTRY* pending_entry = interlocked_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL);
@@ -566,7 +566,7 @@ void clds_hazard_pointers_unregister_thread(CLDS_HAZARD_POINTERS_THREAD_HANDLE c
         /*Codes_SRS_CLDS_HAZARD_POINTERS_01_009: [ clds_hazard_pointers_unregister_thread shall unregister the thread identified by clds_hazard_pointers_thread from its associated hazard pointers instance. ]*/
         CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_thread->clds_hazard_pointers;
 
-        /*Codes_SRS_CLDS_HAZARD_POINTERS_01_025: [ clds_hazard_pointers_unregister_thread shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. ]*/
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_42_001: [ clds_hazard_pointers_unregister_thread shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. ]*/
         // Done before the thread is marked inactive (and thus eligible for cleanup/free) so that
         // nodes retired by this thread but still protected by another thread are not lost.
         CLDS_RECLAIM_LIST_ENTRY* first_reclaim_entry = clds_hazard_pointers_thread->reclaim_list;

--- a/src/clds_hazard_pointers.c
+++ b/src/clds_hazard_pointers.c
@@ -71,10 +71,9 @@ typedef struct CLDS_HAZARD_POINTERS_TAG
     volatile_atomic int32_t pending_reclaim_calls;
     // This is the queue of inactive threads
     TQUEUE(CLDS_HP_INACTIVE_THREAD) inactive_threads;
-    // Single-linked list of reclaim entries handed off by threads that unregistered while another
-    // thread still held a hazard pointer on the retired node. Without this hand-off such entries
-    // (and their reclaim callbacks) would be lost when the thread's data is freed. Pushed lock-free
-    // with an interlocked CAS; drained by internal_reclaim and by clds_hazard_pointers_destroy.
+    // Single-linked list of reclaim entries handed off by threads that unregistered while another thread still held a hazard pointer on the retired node.
+    // Without this hand-off such entries (and their reclaim callbacks) would be lost when the thread's data is freed.
+    // Pushed lock-free with an interlocked CAS; drained by internal_reclaim and by clds_hazard_pointers_destroy.
     CLDS_RECLAIM_LIST_ENTRY* volatile_atomic pending_reclaim_list;
 } CLDS_HAZARD_POINTERS;
 
@@ -273,10 +272,8 @@ static void internal_reclaim(CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_poin
                 }
             }
 
-            // Sweep the global pending reclaim list (entries handed off by threads that
-            // unregistered while their retired node was still protected by another thread).
-            // Detach the whole list atomically, reclaim every entry whose node is no longer
-            // held and re-push the ones that are still protected.
+            // Sweep the global pending reclaim list (entries handed off by threads that unregistered while their retired node was still protected by another thread).
+            // Detach the whole list atomically, reclaim every entry whose node is no longer held and re-push the ones that are still protected.
             /*Codes_SRS_CLDS_HAZARD_POINTERS_42_002: [ When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. ]*/
             CLDS_RECLAIM_LIST_ENTRY* pending_entry = interlocked_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL);
             CLDS_RECLAIM_LIST_ENTRY* still_held_first = NULL;
@@ -487,8 +484,7 @@ void clds_hazard_pointers_destroy(CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointe
         }
 
         /*Codes_SRS_CLDS_HAZARD_POINTERS_42_003: [ clds_hazard_pointers_destroy shall reclaim all entries remaining on the global pending reclaim list. ]*/
-        // all threads are gone now, so no hazard pointer can be held: drain whatever was handed off
-        // by unregistered threads and never reclaimed.
+        // all threads are gone now, so no hazard pointer can be held: drain whatever was handed off by unregistered threads and never reclaimed.
         CLDS_RECLAIM_LIST_ENTRY* pending_entry = interlocked_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL);
         while (pending_entry != NULL)
         {
@@ -567,8 +563,7 @@ void clds_hazard_pointers_unregister_thread(CLDS_HAZARD_POINTERS_THREAD_HANDLE c
         CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_thread->clds_hazard_pointers;
 
         /*Codes_SRS_CLDS_HAZARD_POINTERS_42_001: [ clds_hazard_pointers_unregister_thread shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. ]*/
-        // Done before the thread is marked inactive (and thus eligible for cleanup/free) so that
-        // nodes retired by this thread but still protected by another thread are not lost.
+        // Done before the thread is marked inactive (and thus eligible for cleanup/free) so that nodes retired by this thread but still protected by another thread are not lost.
         CLDS_RECLAIM_LIST_ENTRY* first_reclaim_entry = clds_hazard_pointers_thread->reclaim_list;
         if (first_reclaim_entry != NULL)
         {

--- a/src/clds_hazard_pointers.c
+++ b/src/clds_hazard_pointers.c
@@ -71,6 +71,11 @@ typedef struct CLDS_HAZARD_POINTERS_TAG
     volatile_atomic int32_t pending_reclaim_calls;
     // This is the queue of inactive threads
     TQUEUE(CLDS_HP_INACTIVE_THREAD) inactive_threads;
+    // Single-linked list of reclaim entries handed off by threads that unregistered while another
+    // thread still held a hazard pointer on the retired node. Without this hand-off such entries
+    // (and their reclaim callbacks) would be lost when the thread's data is freed. Pushed lock-free
+    // with an interlocked CAS; drained by internal_reclaim and by clds_hazard_pointers_destroy.
+    CLDS_RECLAIM_LIST_ENTRY* volatile_atomic pending_reclaim_list;
 } CLDS_HAZARD_POINTERS;
 
 static uint64_t hp_key_hash(void* key)
@@ -267,6 +272,50 @@ static void internal_reclaim(CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_poin
                     current_reclaim_entry = current_reclaim_entry->next;
                 }
             }
+
+            // Sweep the global pending reclaim list (entries handed off by threads that
+            // unregistered while their retired node was still protected by another thread).
+            // Detach the whole list atomically, reclaim every entry whose node is no longer
+            // held and re-push the ones that are still protected.
+            /*Codes_SRS_CLDS_HAZARD_POINTERS_01_027: [ internal_reclaim shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. ]*/
+            CLDS_RECLAIM_LIST_ENTRY* pending_entry = interlocked_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL);
+            CLDS_RECLAIM_LIST_ENTRY* still_held_first = NULL;
+            CLDS_RECLAIM_LIST_ENTRY* still_held_last = NULL;
+            while (pending_entry != NULL)
+            {
+                CLDS_RECLAIM_LIST_ENTRY* next_pending_entry = pending_entry->next;
+
+                CLDS_ST_HASH_SET_FIND_RESULT pending_find_result = clds_st_hash_set_find(all_hps_set, pending_entry->node);
+                if (pending_find_result == CLDS_ST_HASH_SET_FIND_NOT_FOUND)
+                {
+                    // node is no longer protected, reclaim it
+                    pending_entry->reclaim(pending_entry->node);
+                    free(pending_entry);
+                }
+                else
+                {
+                    // still protected (or a lookup error): keep it for a later reclaim cycle
+                    pending_entry->next = still_held_first;
+                    still_held_first = pending_entry;
+                    if (still_held_last == NULL)
+                    {
+                        still_held_last = pending_entry;
+                    }
+                }
+
+                pending_entry = next_pending_entry;
+            }
+
+            if (still_held_first != NULL)
+            {
+                // re-push the still-held chain onto the global pending list
+                CLDS_RECLAIM_LIST_ENTRY* current_pending_head;
+                do
+                {
+                    current_pending_head = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL, NULL);
+                    still_held_last->next = current_pending_head;
+                } while (interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, still_held_first, current_pending_head) != current_pending_head);
+            }
         }
 
         clds_st_hash_set_destroy(all_hps_set);
@@ -384,6 +433,7 @@ CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers_create(void)
                     TQUEUE_INITIALIZE_MOVE(CLDS_HP_INACTIVE_THREAD)(&result->inactive_threads, &inactive_threads);
                     result->reclaim_threshold = DEFAULT_RECLAIM_THRESHOLD;
                     (void)interlocked_exchange_pointer((void* volatile_atomic*) & result->head, NULL);
+                    (void)interlocked_exchange_pointer((void* volatile_atomic*) & result->pending_reclaim_list, NULL);
                     (void)interlocked_exchange_64(&result->epoch, 0);
                     (void)interlocked_exchange(&result->pending_reclaim_calls, 0);
 
@@ -434,6 +484,18 @@ void clds_hazard_pointers_destroy(CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointe
             free_thread_data(clds_hazard_pointers_thread);
 
             clds_hazard_pointers_thread = next_clds_hazard_pointers_thread;
+        }
+
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_01_028: [ clds_hazard_pointers_destroy shall reclaim all entries remaining on the global pending reclaim list. ]*/
+        // all threads are gone now, so no hazard pointer can be held: drain whatever was handed off
+        // by unregistered threads and never reclaimed.
+        CLDS_RECLAIM_LIST_ENTRY* pending_entry = interlocked_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL);
+        while (pending_entry != NULL)
+        {
+            CLDS_RECLAIM_LIST_ENTRY* next_pending_entry = pending_entry->next;
+            pending_entry->reclaim(pending_entry->node);
+            free(pending_entry);
+            pending_entry = next_pending_entry;
         }
 
         // free all inactive threads
@@ -503,6 +565,29 @@ void clds_hazard_pointers_unregister_thread(CLDS_HAZARD_POINTERS_THREAD_HANDLE c
     {
         /*Codes_SRS_CLDS_HAZARD_POINTERS_01_009: [ clds_hazard_pointers_unregister_thread shall unregister the thread identified by clds_hazard_pointers_thread from its associated hazard pointers instance. ]*/
         CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_thread->clds_hazard_pointers;
+
+        /*Codes_SRS_CLDS_HAZARD_POINTERS_01_025: [ clds_hazard_pointers_unregister_thread shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. ]*/
+        // Done before the thread is marked inactive (and thus eligible for cleanup/free) so that
+        // nodes retired by this thread but still protected by another thread are not lost.
+        CLDS_RECLAIM_LIST_ENTRY* first_reclaim_entry = clds_hazard_pointers_thread->reclaim_list;
+        if (first_reclaim_entry != NULL)
+        {
+            CLDS_RECLAIM_LIST_ENTRY* last_reclaim_entry = first_reclaim_entry;
+            while (last_reclaim_entry->next != NULL)
+            {
+                last_reclaim_entry = last_reclaim_entry->next;
+            }
+
+            CLDS_RECLAIM_LIST_ENTRY* current_pending_head;
+            do
+            {
+                current_pending_head = interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, NULL, NULL);
+                last_reclaim_entry->next = current_pending_head;
+            } while (interlocked_compare_exchange_pointer((void* volatile_atomic*)&clds_hazard_pointers->pending_reclaim_list, first_reclaim_entry, current_pending_head) != current_pending_head);
+
+            clds_hazard_pointers_thread->reclaim_list = NULL;
+            clds_hazard_pointers_thread->reclaim_list_entry_count = 0;
+        }
 
         // remove the thread from the thread list
         (void)interlocked_exchange(&clds_hazard_pointers_thread->active, 0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 
 #integration tests
 if(${run_int_tests})
+    build_test_folder(clds_hazard_pointers_int)
     build_test_folder(lock_free_set_int)
     build_test_folder(clds_singly_linked_list_int)
 if(WIN32)

--- a/tests/clds_hazard_pointers_int/CMakeLists.txt
+++ b/tests/clds_hazard_pointers_int/CMakeLists.txt
@@ -1,0 +1,15 @@
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+set(theseTestsName clds_hazard_pointers_int)
+
+set(${theseTestsName}_test_files
+${theseTestsName}.c
+)
+
+set(${theseTestsName}_c_files
+)
+
+set(${theseTestsName}_h_files
+)
+
+build_test_artifacts(${theseTestsName} "tests/clds" ADDITIONAL_LIBS clds)

--- a/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
+++ b/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
@@ -85,6 +85,8 @@ TEST_FUNCTION(reclaim_runs_immediately_when_no_hazard_pointer_is_held)
 // unregisters, while another thread still holds a hazard pointer on it, must still be reclaimed.
 // Before the fix the retiring thread's reclaim list was dropped when its data was freed, so the
 // node (and its reclaim callback) leaked forever.
+/* Tests_SRS_CLDS_HAZARD_POINTERS_42_001: [ clds_hazard_pointers_unregister_thread shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. ]*/
+/* Tests_SRS_CLDS_HAZARD_POINTERS_42_003: [ clds_hazard_pointers_destroy shall reclaim all entries remaining on the global pending reclaim list. ]*/
 TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
 {
     // arrange
@@ -108,7 +110,6 @@ TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
     ASSERT_ARE_EQUAL(int32_t, 0, interlocked_add(&g_reclaim_count, 0), "node must not be reclaimed while a hazard pointer is held");
 
     // retiring_thread unregisters and is moved onto the inactive queue by the cleanup worker
-    /*Tests_SRS_CLDS_HAZARD_POINTERS_42_001*/
     clds_hazard_pointers_unregister_thread(retiring_thread);
     ThreadAPI_Sleep(CLEANUP_WORKER_GRACE_MS);
 
@@ -116,7 +117,6 @@ TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
     clds_hazard_pointers_release(holding_thread, held_record);
     clds_hazard_pointers_unregister_thread(holding_thread);
 
-    /*Tests_SRS_CLDS_HAZARD_POINTERS_42_003*/
     clds_hazard_pointers_destroy(clds_hazard_pointers);
 
     // assert
@@ -128,6 +128,7 @@ TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
 // (because the thread that retired it unregistered while the node was still protected) must be
 // reclaimed by the next reclaim cycle that runs on any other live thread, once the node is no longer
 // protected - it must not have to wait for clds_hazard_pointers_destroy.
+/* Tests_SRS_CLDS_HAZARD_POINTERS_42_002: [ When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. ]*/
 TEST_FUNCTION(pending_node_is_reclaimed_by_a_later_reclaim_cycle)
 {
     // arrange
@@ -160,7 +161,6 @@ TEST_FUNCTION(pending_node_is_reclaimed_by_a_later_reclaim_cycle)
     clds_hazard_pointers_release(holding_thread, held_record);
 
     // a reclaim cycle on a different live thread must sweep the pending list and reclaim node
-    /*Tests_SRS_CLDS_HAZARD_POINTERS_42_002*/
     clds_hazard_pointers_reclaim(sweeper_thread, dummy, test_reclaim);
 
     // assert

--- a/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
+++ b/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.See LICENSE file in the project root for full license information.
+
+#include <stdlib.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include "macro_utils/macro_utils.h"
+
+#include "testrunnerswitcher.h"
+
+#include "c_logging/logger.h"
+
+#include "c_pal/gballoc_hl.h"
+#include "c_pal/gballoc_hl_redirect.h"
+#include "c_pal/interlocked.h"
+#include "c_pal/threadapi.h"
+
+#include "clds/clds_hazard_pointers.h"
+
+// Number of milliseconds to wait after unregistering a thread so that the hazard pointers cleanup
+// worker has time to move it onto the inactive threads queue (the worst case for the leak this
+// test guards against - the unregistered thread is fully gone before the instance is destroyed).
+#define CLEANUP_WORKER_GRACE_MS 1500
+
+// Counts how many times the test reclaim callback ran. The reclaim callback signature has no
+// context, so a file-scope atomic is used and reset at the start of each test.
+static volatile_atomic int32_t g_reclaim_count;
+
+static void test_reclaim(void* node)
+{
+    // free the node so that the absence of a reclaim (the bug) shows up as a leak under VLD/ASAN,
+    // and bump the counter so the leak is also detectable as a deterministic assertion failure.
+    free(node);
+    (void)interlocked_increment(&g_reclaim_count);
+}
+
+BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
+
+TEST_SUITE_INITIALIZE(suite_init)
+{
+    ASSERT_ARE_EQUAL(int, 0, gballoc_hl_init(NULL, NULL));
+}
+
+TEST_SUITE_CLEANUP(suite_cleanup)
+{
+    gballoc_hl_deinit();
+}
+
+TEST_FUNCTION_INITIALIZE(method_init)
+{
+    (void)interlocked_exchange(&g_reclaim_count, 0);
+}
+
+TEST_FUNCTION_CLEANUP(method_cleanup)
+{
+}
+
+// Control: with no hazard pointer held on the node, a reclaim must run immediately (the default
+// reclaim threshold is 1). This proves the reclaim wiring is correct, so a 0 count in the bug test
+// below is meaningful rather than a broken harness.
+TEST_FUNCTION(reclaim_runs_immediately_when_no_hazard_pointer_is_held)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(clds_hazard_pointers);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    ASSERT_IS_NOT_NULL(thread);
+    int* node = malloc(sizeof(int));
+    ASSERT_IS_NOT_NULL(node);
+
+    // act
+    // no hazard pointer is held on node, so this reclaim should run right away
+    clds_hazard_pointers_reclaim(thread, node, test_reclaim);
+
+    // assert
+    ASSERT_ARE_EQUAL(int32_t, 1, interlocked_add(&g_reclaim_count, 0));
+
+    // cleanup
+    clds_hazard_pointers_unregister_thread(thread);
+    clds_hazard_pointers_destroy(clds_hazard_pointers);
+}
+
+// Regression for the leak fixed by Task #36604983: a node retired by a thread that then
+// unregisters, while another thread still holds a hazard pointer on it, must still be reclaimed.
+// Before the fix the retiring thread's reclaim list was dropped when its data was freed, so the
+// node (and its reclaim callback) leaked forever.
+TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(clds_hazard_pointers);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE retiring_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    ASSERT_IS_NOT_NULL(retiring_thread);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE holding_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    ASSERT_IS_NOT_NULL(holding_thread);
+    int* node = malloc(sizeof(int));
+    ASSERT_IS_NOT_NULL(node);
+
+    // holding_thread protects node with a hazard pointer so it cannot be reclaimed yet
+    CLDS_HAZARD_POINTER_RECORD_HANDLE held_record = clds_hazard_pointers_acquire(holding_thread, node);
+    ASSERT_IS_NOT_NULL(held_record);
+
+    // act
+    // retiring_thread retires node while holding_thread still protects it: node is stranded on
+    // retiring_thread's reclaim list
+    clds_hazard_pointers_reclaim(retiring_thread, node, test_reclaim);
+    ASSERT_ARE_EQUAL(int32_t, 0, interlocked_add(&g_reclaim_count, 0), "node must not be reclaimed while a hazard pointer is held");
+
+    // retiring_thread unregisters and is moved onto the inactive queue by the cleanup worker
+    /*Tests_SRS_CLDS_HAZARD_POINTERS_01_025*/
+    clds_hazard_pointers_unregister_thread(retiring_thread);
+    ThreadAPI_Sleep(CLEANUP_WORKER_GRACE_MS);
+
+    // the last holder releases and unregisters; node now has no protector
+    clds_hazard_pointers_release(holding_thread, held_record);
+    clds_hazard_pointers_unregister_thread(holding_thread);
+
+    /*Tests_SRS_CLDS_HAZARD_POINTERS_01_028*/
+    clds_hazard_pointers_destroy(clds_hazard_pointers);
+
+    // assert
+    // the node retired by the now-gone retiring_thread must still have been reclaimed exactly once
+    ASSERT_ARE_EQUAL(int32_t, 1, interlocked_add(&g_reclaim_count, 0), "stranded node was never reclaimed (leak)");
+}
+
+// Regression for the live sweep path: a node handed off to the instance-wide pending reclaim list
+// (because the thread that retired it unregistered while the node was still protected) must be
+// reclaimed by the next reclaim cycle that runs on any other live thread, once the node is no longer
+// protected - it must not have to wait for clds_hazard_pointers_destroy.
+TEST_FUNCTION(pending_node_is_reclaimed_by_a_later_reclaim_cycle)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(clds_hazard_pointers);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE retiring_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    ASSERT_IS_NOT_NULL(retiring_thread);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE holding_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    ASSERT_IS_NOT_NULL(holding_thread);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE sweeper_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    ASSERT_IS_NOT_NULL(sweeper_thread);
+    int* node = malloc(sizeof(int));
+    ASSERT_IS_NOT_NULL(node);
+    int* dummy = malloc(sizeof(int));
+    ASSERT_IS_NOT_NULL(dummy);
+
+    // holding_thread protects node with a hazard pointer so it cannot be reclaimed yet
+    CLDS_HAZARD_POINTER_RECORD_HANDLE held_record = clds_hazard_pointers_acquire(holding_thread, node);
+    ASSERT_IS_NOT_NULL(held_record);
+
+    // act
+    // retiring_thread retires node (stranded on its reclaim list because node is protected) then
+    // unregisters, handing the entry off to the instance-wide pending reclaim list
+    clds_hazard_pointers_reclaim(retiring_thread, node, test_reclaim);
+    clds_hazard_pointers_unregister_thread(retiring_thread);
+    ThreadAPI_Sleep(CLEANUP_WORKER_GRACE_MS);
+    ASSERT_ARE_EQUAL(int32_t, 0, interlocked_add(&g_reclaim_count, 0), "node must not be reclaimed while a hazard pointer is held");
+
+    // the holder releases so node is now unprotected, but no reclaim cycle has run yet
+    clds_hazard_pointers_release(holding_thread, held_record);
+
+    // a reclaim cycle on a different live thread must sweep the pending list and reclaim node
+    /*Tests_SRS_CLDS_HAZARD_POINTERS_01_027*/
+    clds_hazard_pointers_reclaim(sweeper_thread, dummy, test_reclaim);
+
+    // assert
+    // both the dummy (reclaimed directly by the sweeper) and the stranded node (swept from the
+    // pending list during the sweeper's reclaim cycle, before any destroy) must have run
+    ASSERT_ARE_EQUAL(int32_t, 2, interlocked_add(&g_reclaim_count, 0), "pending node was not swept by a later reclaim cycle");
+
+    // cleanup
+    clds_hazard_pointers_unregister_thread(holding_thread);
+    clds_hazard_pointers_unregister_thread(sweeper_thread);
+    clds_hazard_pointers_destroy(clds_hazard_pointers);
+}
+
+END_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)

--- a/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
+++ b/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
@@ -108,7 +108,7 @@ TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
     ASSERT_ARE_EQUAL(int32_t, 0, interlocked_add(&g_reclaim_count, 0), "node must not be reclaimed while a hazard pointer is held");
 
     // retiring_thread unregisters and is moved onto the inactive queue by the cleanup worker
-    /*Tests_SRS_CLDS_HAZARD_POINTERS_01_025*/
+    /*Tests_SRS_CLDS_HAZARD_POINTERS_42_001*/
     clds_hazard_pointers_unregister_thread(retiring_thread);
     ThreadAPI_Sleep(CLEANUP_WORKER_GRACE_MS);
 
@@ -116,7 +116,7 @@ TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
     clds_hazard_pointers_release(holding_thread, held_record);
     clds_hazard_pointers_unregister_thread(holding_thread);
 
-    /*Tests_SRS_CLDS_HAZARD_POINTERS_01_028*/
+    /*Tests_SRS_CLDS_HAZARD_POINTERS_42_003*/
     clds_hazard_pointers_destroy(clds_hazard_pointers);
 
     // assert
@@ -160,7 +160,7 @@ TEST_FUNCTION(pending_node_is_reclaimed_by_a_later_reclaim_cycle)
     clds_hazard_pointers_release(holding_thread, held_record);
 
     // a reclaim cycle on a different live thread must sweep the pending list and reclaim node
-    /*Tests_SRS_CLDS_HAZARD_POINTERS_01_027*/
+    /*Tests_SRS_CLDS_HAZARD_POINTERS_42_002*/
     clds_hazard_pointers_reclaim(sweeper_thread, dummy, test_reclaim);
 
     // assert

--- a/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
+++ b/tests/clds_hazard_pointers_int/clds_hazard_pointers_int.c
@@ -81,12 +81,12 @@ TEST_FUNCTION(reclaim_runs_immediately_when_no_hazard_pointer_is_held)
     clds_hazard_pointers_destroy(clds_hazard_pointers);
 }
 
-// Regression for the leak fixed by Task #36604983: a node retired by a thread that then
-// unregisters, while another thread still holds a hazard pointer on it, must still be reclaimed.
-// Before the fix the retiring thread's reclaim list was dropped when its data was freed, so the
-// node (and its reclaim callback) leaked forever.
-/* Tests_SRS_CLDS_HAZARD_POINTERS_42_001: [ clds_hazard_pointers_unregister_thread shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. ]*/
-/* Tests_SRS_CLDS_HAZARD_POINTERS_42_003: [ clds_hazard_pointers_destroy shall reclaim all entries remaining on the global pending reclaim list. ]*/
+// Regression test (Task #36604983) for a leak in the reclaim list. Does the following:
+// - holding_thread acquires a hazard pointer on node
+// - retiring_thread retires node (stranded, since node is still protected) then unregisters
+// - holding_thread releases and unregisters, so node is now unprotected
+// - the instance is destroyed
+// Expect: node is reclaimed exactly once (before the fix it leaked when retiring_thread's data was freed).
 TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
 {
     // arrange
@@ -124,11 +124,12 @@ TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed)
     ASSERT_ARE_EQUAL(int32_t, 1, interlocked_add(&g_reclaim_count, 0), "stranded node was never reclaimed (leak)");
 }
 
-// Regression for the live sweep path: a node handed off to the instance-wide pending reclaim list
-// (because the thread that retired it unregistered while the node was still protected) must be
-// reclaimed by the next reclaim cycle that runs on any other live thread, once the node is no longer
-// protected - it must not have to wait for clds_hazard_pointers_destroy.
-/* Tests_SRS_CLDS_HAZARD_POINTERS_42_002: [ When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. ]*/
+// Regression test for the live sweep path. Does the following:
+// - holding_thread acquires a hazard pointer on node
+// - retiring_thread retires node (stranded) then unregisters, handing the entry to the instance pending list
+// - holding_thread releases, so node is now unprotected
+// - sweeper_thread runs a reclaim cycle (reclaiming an unrelated dummy node)
+// Expect: the sweeper's reclaim cycle also reclaims node from the pending list, before any destroy.
 TEST_FUNCTION(pending_node_is_reclaimed_by_a_later_reclaim_cycle)
 {
     // arrange

--- a/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut.c
+++ b/tests/clds_hazard_pointers_ut/clds_hazard_pointers_ut.c
@@ -25,6 +25,18 @@ MOCK_FUNCTION_END()
 
 static WORKER_THREAD_HANDLE test_worker_thread = (WORKER_THREAD_HANDLE)0x4242;
 
+// Plain (non-mock) reclaim callback used by the global pending reclaim list tests below. Those tests
+// assert how many reclaims ran (and on which node) across the multi-thread hand-off and sweep paths,
+// which is clearer with a counter than with strict mock-call accounting over those paths. The node
+// pointers are never dereferenced, so this callback only records, it does not free.
+static int g_pending_reclaim_count;
+static void* g_last_reclaimed_node;
+static void count_reclaim(void* node)
+{
+    g_last_reclaimed_node = node;
+    g_pending_reclaim_count++;
+}
+
 BEGIN_TEST_SUITE(TEST_SUITE_NAME_FROM_CMAKE)
 
 TEST_SUITE_INITIALIZE(suite_init)
@@ -448,6 +460,70 @@ TEST_FUNCTION(clds_hazard_pointers_reclaim_with_a_pointer_that_is_not_acquired_r
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
     // cleanup
+    clds_hazard_pointers_destroy(clds_hazard_pointers);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_42_001: [ clds_hazard_pointers_unregister_thread shall hand off any entries still on the thread's reclaim list to the global pending reclaim list of the hazard pointers instance. ]*/
+/*Tests_SRS_CLDS_HAZARD_POINTERS_42_003: [ clds_hazard_pointers_destroy shall reclaim all entries remaining on the global pending reclaim list. ]*/
+TEST_FUNCTION(node_retired_by_unregistering_thread_while_held_is_reclaimed_on_destroy)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_create();
+    (void)clds_hazard_pointers_set_reclaim_threshold(clds_hazard_pointers, 1);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE retiring_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE holding_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    void* node = (void*)0x4242;
+    // holding_thread protects node so it cannot be reclaimed yet
+    CLDS_HAZARD_POINTER_RECORD_HANDLE held_record = clds_hazard_pointers_acquire(holding_thread, node);
+    // retiring_thread retires node while it is still protected, so node stays on retiring_thread's reclaim list
+    clds_hazard_pointers_reclaim(retiring_thread, node, count_reclaim);
+    g_pending_reclaim_count = 0;
+    g_last_reclaimed_node = NULL;
+
+    // act
+    // retiring_thread hands its reclaim list off to the instance pending list, then the holder releases and the instance is destroyed
+    clds_hazard_pointers_unregister_thread(retiring_thread);
+    clds_hazard_pointers_release(holding_thread, held_record);
+    clds_hazard_pointers_unregister_thread(holding_thread);
+    clds_hazard_pointers_destroy(clds_hazard_pointers);
+
+    // assert
+    ASSERT_ARE_EQUAL(int, 1, g_pending_reclaim_count);
+    ASSERT_ARE_EQUAL(void_ptr, node, g_last_reclaimed_node);
+}
+
+/*Tests_SRS_CLDS_HAZARD_POINTERS_42_002: [ When a reclaim cycle is triggered, it shall also reclaim each entry on the global pending reclaim list whose node is no longer protected by any hazard pointer and re-park the rest. ]*/
+TEST_FUNCTION(pending_node_is_reclaimed_by_a_later_reclaim_cycle)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE clds_hazard_pointers = clds_hazard_pointers_create();
+    (void)clds_hazard_pointers_set_reclaim_threshold(clds_hazard_pointers, 1);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE retiring_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE holding_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE sweeper_thread = clds_hazard_pointers_register_thread(clds_hazard_pointers);
+    void* node = (void*)0x4242;
+    void* dummy = (void*)0x4243;
+    // holding_thread protects node so it cannot be reclaimed yet
+    CLDS_HAZARD_POINTER_RECORD_HANDLE held_record = clds_hazard_pointers_acquire(holding_thread, node);
+    // retiring_thread retires node (stranded, since node is protected) then hands it off to the instance pending list
+    clds_hazard_pointers_reclaim(retiring_thread, node, count_reclaim);
+    clds_hazard_pointers_unregister_thread(retiring_thread);
+    // the holder releases so node is now unprotected, but no reclaim cycle has run yet
+    clds_hazard_pointers_release(holding_thread, held_record);
+    g_pending_reclaim_count = 0;
+    g_last_reclaimed_node = NULL;
+
+    // act
+    // a reclaim cycle on a different live thread must sweep the pending list and reclaim node, before any destroy
+    clds_hazard_pointers_reclaim(sweeper_thread, dummy, count_reclaim);
+
+    // assert
+    // both the dummy (reclaimed directly) and node (swept from the pending list) must have run
+    ASSERT_ARE_EQUAL(int, 2, g_pending_reclaim_count);
+
+    // cleanup
+    clds_hazard_pointers_unregister_thread(holding_thread);
+    clds_hazard_pointers_unregister_thread(sweeper_thread);
     clds_hazard_pointers_destroy(clds_hazard_pointers);
 }
 


### PR DESCRIPTION
## Summary
Fixes ADO Task #36604983 (https://msazure.visualstudio.com/One/_workitems/edit/36604983) - a hazard-pointers memory leak in clds that surfaced as a leak failure in `resource_pool_partition_int` on a gated build.

## Root cause
`clds_hazard_pointers_unregister_thread` set the thread inactive and scheduled the cleanup worker but never drained the thread's `reclaim_list`. `free_thread_data` frees the thread's hazard-pointer records and the thread struct but ignores `reclaim_list`. So if a thread retired a node (via `clds_hazard_pointers_reclaim`) while another thread momentarily held a hazard pointer on it, that node was parked on the retiring thread's reclaim list - and was lost forever (node + reclaim callback leaked) when the thread unregistered and its data was freed. With `DEFAULT_RECLAIM_THRESHOLD == 1` every reclaim triggers `internal_reclaim`, which only ever processed the calling thread's own list, so nothing else picked the orphaned entry up.

## The fix
- Add an instance-wide `pending_reclaim_list` (lock-free, intrusive single-linked list).
- `clds_hazard_pointers_unregister_thread` hands off the whole `reclaim_list` chain to `pending_reclaim_list` via a CAS, **before** marking the thread inactive (so it is not yet eligible for cleanup/free).
- `internal_reclaim` atomically detaches `pending_reclaim_list` each cycle, reclaims every entry whose node is no longer protected by any hazard pointer, and re-pushes the still-protected ones.
- `clds_hazard_pointers_destroy` drains `pending_reclaim_list` after all threads are gone (no hazard pointer can be held at that point).

The epoch-style design is preserved; `reclaim_list` remains thread-local (only the owning thread mutates it), so the hand-off needs no extra locking. A lookup error from `clds_st_hash_set_find` is treated as "still held" (re-park), which is the safe choice - it can never wrongly reclaim a live node.

## Verification
- Local build: **PASS** (VS 2026 / MSVC 14.51, Debug).
- New unit tests in `clds_hazard_pointers_ut` cover all three specs (hand-off reclaimed on destroy, pending entry swept by a later reclaim cycle): **PASS** (24 tests, 0 failed).
- `clds_hazard_pointers_int` retained as untagged regression coverage (regression + live-sweep + control): **3/3 green** with the fix.
- Negative control: with the fix reverted, the regression test **fails** deterministically (`stranded node was never reclaimed (leak) Expected: 1, Actual: 0`), proving it guards the bug.
- Heavy concurrency smoke `clds_hash_table_int` (~10 min): **PASS** - no regression in the normal reclaim path.

## Performance
Re-tested rigorously after review feedback. Earlier method (5 runs per branch, sampled in **blocks**) produced misleadingly large swings (a physically-impossible +17/18% "gain" on hash_table Insert/Find) because run-to-run environmental drift between the master-block and the PR-block leaked into the delta. The re-test uses an **interleaved A/B design** (master and PR back-to-back each round, order flipped every round) at **20 rounds = 40 samples/arm**, plus an **identical-code master-vs-master control** to measure the true noise floor. Result: every real PR-vs-master mean delta is now **<= 5.4%** (hash_table Insert/Find = -1.9%/-1.9%), and the identical-code control reproduces the **same or larger** swings (e.g. sll Delete identical-code spread = 88% min-to-max; sorted Delete control range [-32%, +36%]). **No measurable regression** on any path, including the reclaim-heavy Delete/Remove paths where a sweep cost would surface first. This matches the design: when the pending list is empty (the common case) the sweep adds one `interlocked_exchange_pointer` (returns NULL) plus a NULL check per reclaim cycle, and the unregister hand-off is O(1). Full tables (both experiments + noise floor) and method: https://github.com/Azure/clds/pull/440#issuecomment-4696162173
## Traceability
Added `SRS_CLDS_HAZARD_POINTERS_42_001` (unregister hand-off), `_42_002` (internal_reclaim sweep), `_42_003` (destroy drain) to the devdoc, with matching `Codes_` markers in the source and `Tests_` markers in the **unit tests** (`clds_hazard_pointers_ut`). Traceability tool: 0 failing requirements.

## MrBot session
- Action: `FIX` + `ADDRESS_FEEDBACK`
- Investigated by MrBot; humans authorised the fix via `/proceed` on the task.
